### PR TITLE
Chore/tests

### DIFF
--- a/docs/schema_test.go
+++ b/docs/schema_test.go
@@ -1,0 +1,526 @@
+package docs
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/joakimcarlsson/go-router/metadata"
+)
+
+// MockUUID mimics uuid.UUID structure ([16]byte array) without external dependency
+type MockUUID [16]byte
+
+// String implements the same interface as uuid.UUID for testing
+func (u MockUUID) String() string {
+	return "123e4567-e89b-12d3-a456-426614174000"
+}
+
+// Test types for schema generation
+type TestUser struct {
+	ID       MockUUID   `json:"id"`
+	Name     string     `json:"name" validate:"required"`
+	Email    *string    `json:"email"`
+	Age      int        `json:"age" validate:"min=0"`
+	Score    float64    `json:"score"`
+	Active   bool       `json:"active"`
+	Created  time.Time  `json:"created"`
+	Updated  *time.Time `json:"updated"`
+	Tags     []string   `json:"tags"`
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+type TestProduct struct {
+	ID          MockUUID `json:"id"`
+	Name        string   `json:"name"`
+	Price       float64  `json:"price"`
+	Description *string  `json:"description"`
+}
+
+func TestSchemaFromType_UUID(t *testing.T) {
+	// Register MockUUID to behave like real uuid.UUID
+	metadata.RegisterTypeHandler("docs.MockUUID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "uuid",
+			Example:  "123e4567-e89b-12d3-a456-426614174000",
+			TypeName: "UUID",
+		}
+	})
+	
+	schema := SchemaFromType(reflect.TypeOf(MockUUID{}))
+	
+	if schema.Type != "string" {
+		t.Errorf("Expected UUID type to be 'string', got '%s'", schema.Type)
+	}
+	
+	if schema.Format != "uuid" {
+		t.Errorf("Expected UUID format to be 'uuid', got '%s'", schema.Format)
+	}
+	
+	if schema.Example != "123e4567-e89b-12d3-a456-426614174000" {
+		t.Errorf("Expected UUID example to be '123e4567-e89b-12d3-a456-426614174000', got '%v'", schema.Example)
+	}
+	
+	if schema.TypeName != "UUID" {
+		t.Errorf("Expected UUID TypeName to be 'UUID', got '%s'", schema.TypeName)
+	}
+}
+
+func TestSchemaFromType_TimeTime(t *testing.T) {
+	schema := SchemaFromType(reflect.TypeOf(time.Time{}))
+	
+	if schema.Type != "string" {
+		t.Errorf("Expected time.Time type to be 'string', got '%s'", schema.Type)
+	}
+	
+	if schema.Format != "date-time" {
+		t.Errorf("Expected time.Time format to be 'date-time', got '%s'", schema.Format)
+	}
+	
+	if schema.TypeName != "time.Time" {
+		t.Errorf("Expected time.Time TypeName to be 'time.Time', got '%s'", schema.TypeName)
+	}
+	
+	// Check that example is a valid RFC3339 format
+	if schema.Example == nil {
+		t.Error("Expected time.Time example to be set")
+	}
+}
+
+func TestSchemaFromType_BasicTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		typ          reflect.Type
+		expectedType string
+		expectedExample interface{}
+	}{
+		{"string", reflect.TypeOf(""), "string", "example"},
+		{"int", reflect.TypeOf(0), "integer", 42},
+		{"int32", reflect.TypeOf(int32(0)), "integer", 42},
+		{"int64", reflect.TypeOf(int64(0)), "integer", 42},
+		{"float32", reflect.TypeOf(float32(0)), "number", 3.14},
+		{"float64", reflect.TypeOf(float64(0)), "number", 3.14},
+		{"bool", reflect.TypeOf(false), "boolean", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schema := SchemaFromType(test.typ)
+			
+			if schema.Type != test.expectedType {
+				t.Errorf("Expected %s type to be '%s', got '%s'", test.name, test.expectedType, schema.Type)
+			}
+			
+			if schema.Example != test.expectedExample {
+				t.Errorf("Expected %s example to be '%v', got '%v'", test.name, test.expectedExample, schema.Example)
+			}
+		})
+	}
+}
+
+func TestSchemaFromType_Pointer(t *testing.T) {
+	// Test pointer to string
+	schema := SchemaFromType(reflect.TypeOf((*string)(nil)))
+	
+	if schema.Type != "string" {
+		t.Errorf("Expected *string type to be 'string', got '%s'", schema.Type)
+	}
+	
+	if !schema.Nullable {
+		t.Error("Expected *string to be nullable")
+	}
+}
+
+func TestSchemaFromType_Slice(t *testing.T) {
+	// Test slice of strings
+	schema := SchemaFromType(reflect.TypeOf([]string{}))
+	
+	if schema.Type != "array" {
+		t.Errorf("Expected []string type to be 'array', got '%s'", schema.Type)
+	}
+	
+	if schema.Items == nil {
+		t.Fatal("Expected []string to have Items schema")
+	}
+	
+	if schema.Items.Type != "string" {
+		t.Errorf("Expected []string items type to be 'string', got '%s'", schema.Items.Type)
+	}
+	
+	if schema.TypeName != "[]string" {
+		t.Errorf("Expected []string TypeName to be '[]string', got '%s'", schema.TypeName)
+	}
+}
+
+func TestSchemaFromType_SliceOfUUID(t *testing.T) {
+	// Register MockUUID to behave like real uuid.UUID
+	metadata.RegisterTypeHandler("docs.MockUUID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "uuid",
+			Example:  "123e4567-e89b-12d3-a456-426614174000",
+			TypeName: "UUID",
+		}
+	})
+	
+	// Test that slice of UUID works correctly (should not be confused with UUID itself)
+	schema := SchemaFromType(reflect.TypeOf([]MockUUID{}))
+	
+	if schema.Type != "array" {
+		t.Errorf("Expected []MockUUID type to be 'array', got '%s'", schema.Type)
+	}
+	
+	if schema.Items == nil {
+		t.Fatal("Expected []MockUUID to have Items schema")
+	}
+	
+	if schema.Items.Type != "string" {
+		t.Errorf("Expected []MockUUID items type to be 'string', got '%s'", schema.Items.Type)
+	}
+	
+	if schema.Items.Format != "uuid" {
+		t.Errorf("Expected []MockUUID items format to be 'uuid', got '%s'", schema.Items.Format)
+	}
+}
+
+func TestSchemaFromType_Struct(t *testing.T) {
+	// Register MockUUID to behave like real uuid.UUID
+	metadata.RegisterTypeHandler("docs.MockUUID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "uuid",
+			Example:  "123e4567-e89b-12d3-a456-426614174000",
+			TypeName: "UUID",
+		}
+	})
+	
+	schema := SchemaFromType(reflect.TypeOf(TestUser{}))
+	
+	if schema.Type != "object" {
+		t.Errorf("Expected TestUser type to be 'object', got '%s'", schema.Type)
+	}
+	
+	if schema.Properties == nil {
+		t.Fatal("Expected TestUser to have Properties")
+	}
+	
+	// Test UUID field
+	idProp, exists := schema.Properties["id"]
+	if !exists {
+		t.Fatal("Expected TestUser to have 'id' property")
+	}
+	
+	if idProp.Type != "string" {
+		t.Errorf("Expected TestUser.id type to be 'string', got '%s'", idProp.Type)
+	}
+	
+	if idProp.Format != "uuid" {
+		t.Errorf("Expected TestUser.id format to be 'uuid', got '%s'", idProp.Format)
+	}
+	
+	// Test time.Time field
+	createdProp, exists := schema.Properties["created"]
+	if !exists {
+		t.Fatal("Expected TestUser to have 'created' property")
+	}
+	
+	if createdProp.Type != "string" {
+		t.Errorf("Expected TestUser.created type to be 'string', got '%s'", createdProp.Type)
+	}
+	
+	if createdProp.Format != "date-time" {
+		t.Errorf("Expected TestUser.created format to be 'date-time', got '%s'", createdProp.Format)
+	}
+	
+	// Test nullable pointer field
+	emailProp, exists := schema.Properties["email"]
+	if !exists {
+		t.Fatal("Expected TestUser to have 'email' property")
+	}
+	
+	if !emailProp.Nullable {
+		t.Error("Expected TestUser.email to be nullable")
+	}
+	
+	// Test array field
+	tagsProp, exists := schema.Properties["tags"]
+	if !exists {
+		t.Fatal("Expected TestUser to have 'tags' property")
+	}
+	
+	if tagsProp.Type != "array" {
+		t.Errorf("Expected TestUser.tags type to be 'array', got '%s'", tagsProp.Type)
+	}
+	
+	if tagsProp.Items == nil {
+		t.Fatal("Expected TestUser.tags to have Items schema")
+	}
+	
+	if tagsProp.Items.Type != "string" {
+		t.Errorf("Expected TestUser.tags items type to be 'string', got '%s'", tagsProp.Items.Type)
+	}
+	
+	// Test required fields
+	expectedRequired := []string{"name"}
+	if len(schema.Required) != len(expectedRequired) {
+		t.Errorf("Expected %d required fields, got %d", len(expectedRequired), len(schema.Required))
+	}
+	
+	for _, req := range expectedRequired {
+		found := false
+		for _, actual := range schema.Required {
+			if actual == req {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected field '%s' to be required", req)
+		}
+	}
+}
+
+func TestSchemaFromType_SliceOfStructs(t *testing.T) {
+	// Register MockUUID to behave like real uuid.UUID
+	metadata.RegisterTypeHandler("docs.MockUUID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "uuid",
+			Example:  "123e4567-e89b-12d3-a456-426614174000",
+			TypeName: "UUID",
+		}
+	})
+	
+	schema := SchemaFromType(reflect.TypeOf([]TestProduct{}))
+	
+	if schema.Type != "array" {
+		t.Errorf("Expected []TestProduct type to be 'array', got '%s'", schema.Type)
+	}
+	
+	if schema.Items == nil {
+		t.Fatal("Expected []TestProduct to have Items schema")
+	}
+	
+	if schema.Items.Type != "object" {
+		t.Errorf("Expected []TestProduct items type to be 'object', got '%s'", schema.Items.Type)
+	}
+	
+	// Check that the item schema has the expected properties
+	if schema.Items.Properties == nil {
+		t.Fatal("Expected []TestProduct items to have Properties")
+	}
+	
+	idProp, exists := schema.Items.Properties["id"]
+	if !exists {
+		t.Fatal("Expected TestProduct item to have 'id' property")
+	}
+	
+	if idProp.Type != "string" || idProp.Format != "uuid" {
+		t.Errorf("Expected TestProduct.id to be string with uuid format, got type='%s' format='%s'", 
+			idProp.Type, idProp.Format)
+	}
+}
+
+func TestGetTypeFromGeneric(t *testing.T) {
+	// Test the helper function
+	mockUUIDType := GetTypeFromGeneric[MockUUID]()
+	if mockUUIDType.String() != "docs.MockUUID" {
+		t.Errorf("Expected GetTypeFromGeneric[MockUUID]() to return docs.MockUUID type, got %s", mockUUIDType.String())
+	}
+	
+	stringType := GetTypeFromGeneric[string]()
+	if stringType.Kind() != reflect.String {
+		t.Errorf("Expected GetTypeFromGeneric[string]() to return string kind, got %s", stringType.Kind())
+	}
+	
+	sliceType := GetTypeFromGeneric[[]TestProduct]()
+	if sliceType.Kind() != reflect.Slice {
+		t.Errorf("Expected GetTypeFromGeneric[[]TestProduct]() to return slice kind, got %s", sliceType.Kind())
+	}
+}
+
+func TestIsArrayType(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      reflect.Type
+		expected bool
+	}{
+		{"MockUUID", reflect.TypeOf(MockUUID{}), true},
+		{"[]string", reflect.TypeOf([]string{}), true},
+		{"[5]int", reflect.TypeOf([5]int{}), true},
+		{"string", reflect.TypeOf(""), false},
+		{"int", reflect.TypeOf(0), false},
+		{"struct", reflect.TypeOf(TestUser{}), false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsArrayType(test.typ)
+			if result != test.expected {
+				t.Errorf("Expected IsArrayType(%s) to be %t, got %t", test.name, test.expected, result)
+			}
+		})
+	}
+}
+
+// TestValidation tests that validation tags are properly handled
+func TestSchemaFromType_ValidationTags(t *testing.T) {
+	// Register MockUUID to behave like real uuid.UUID
+	metadata.RegisterTypeHandler("docs.MockUUID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "uuid",
+			Example:  "123e4567-e89b-12d3-a456-426614174000",
+			TypeName: "UUID",
+		}
+	})
+	
+	schema := SchemaFromType(reflect.TypeOf(TestUser{}))
+	
+	// Test minimum validation on age field
+	ageProp, exists := schema.Properties["age"]
+	if !exists {
+		t.Fatal("Expected TestUser to have 'age' property")
+	}
+	
+	if ageProp.Minimum == nil {
+		t.Fatal("Expected TestUser.age to have minimum validation")
+	}
+	
+	if *ageProp.Minimum != 0 {
+		t.Errorf("Expected TestUser.age minimum to be 0, got %f", *ageProp.Minimum)
+	}
+}
+
+// TestCustomTypeHandler tests that custom type handlers work correctly
+func TestCustomTypeHandler(t *testing.T) {
+	// Define a custom type
+	type CustomID int64
+	
+	// Register a custom handler
+	metadata.RegisterTypeHandler("docs.CustomID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "custom-id",
+			Example:  "CUSTOM-12345",
+			TypeName: "CustomID",
+		}
+	})
+	
+	// Test that our custom handler is used
+	schema := SchemaFromType(reflect.TypeOf(CustomID(0)))
+	
+	if schema.Type != "string" {
+		t.Errorf("Expected CustomID type to be 'string', got '%s'", schema.Type)
+	}
+	
+	if schema.Format != "custom-id" {
+		t.Errorf("Expected CustomID format to be 'custom-id', got '%s'", schema.Format)
+	}
+	
+	if schema.Example != "CUSTOM-12345" {
+		t.Errorf("Expected CustomID example to be 'CUSTOM-12345', got '%v'", schema.Example)
+	}
+}
+
+// TestEdgeCases tests edge cases and potential issues
+func TestSchemaFromType_EdgeCases(t *testing.T) {
+	t.Run("empty struct", func(t *testing.T) {
+		type EmptyStruct struct{}
+		schema := SchemaFromType(reflect.TypeOf(EmptyStruct{}))
+		
+		if schema.Type != "object" {
+			t.Errorf("Expected empty struct type to be 'object', got '%s'", schema.Type)
+		}
+		
+		if schema.Properties == nil {
+			// Properties can be nil for empty structs, this is acceptable
+		} else if len(schema.Properties) != 0 {
+			t.Errorf("Expected empty struct to have 0 properties, got %d", len(schema.Properties))
+		}
+	})
+	
+	t.Run("nested structs", func(t *testing.T) {
+		type Address struct {
+			Street string `json:"street"`
+			City   string `json:"city"`
+		}
+		
+		type Person struct {
+			Name    string  `json:"name"`
+			Address Address `json:"address"`
+		}
+		
+		schema := SchemaFromType(reflect.TypeOf(Person{}))
+		
+		if schema.Type != "object" {
+			t.Errorf("Expected Person type to be 'object', got '%s'", schema.Type)
+		}
+		
+		addressProp, exists := schema.Properties["address"]
+		if !exists {
+			t.Fatal("Expected Person to have 'address' property")
+		}
+		
+		if addressProp.Type != "object" {
+			t.Errorf("Expected Person.address type to be 'object', got '%s'", addressProp.Type)
+		}
+		
+		if addressProp.Properties == nil {
+			t.Fatal("Expected Person.address to have properties")
+		}
+		
+		streetProp, exists := addressProp.Properties["street"]
+		if !exists {
+			t.Fatal("Expected Address to have 'street' property")
+		}
+		
+		if streetProp.Type != "string" {
+			t.Errorf("Expected Address.street type to be 'string', got '%s'", streetProp.Type)
+		}
+	})
+}
+
+// TestUUIDBugFix tests the specific UUID array bug that was fixed
+func TestUUIDBugFix(t *testing.T) {
+	// This test verifies that our fix correctly handles array types that should be treated as UUIDs
+	// versus normal array types that should remain as arrays
+	
+	t.Run("normal array remains array", func(t *testing.T) {
+		// Normal [16]byte array should remain as array (no special UUID handling)
+		schema := SchemaFromType(reflect.TypeOf([16]byte{}))
+		
+		if schema.Type != "array" {
+			t.Errorf("Expected normal [16]byte to be 'array', got '%s'", schema.Type)
+		}
+		
+		if schema.Items == nil || schema.Items.Type != "integer" {
+			t.Error("Expected normal [16]byte to have integer items")
+		}
+	})
+	
+	
+	t.Run("MockUUID with handler is UUID", func(t *testing.T) {
+		// Register MockUUID to behave like uuid.UUID
+		metadata.RegisterTypeHandler("docs.MockUUID", func(t reflect.Type) metadata.Schema {
+			return metadata.Schema{
+				Type:     "string",
+				Format:   "uuid",
+				Example:  "123e4567-e89b-12d3-a456-426614174000",
+				TypeName: "UUID",
+			}
+		})
+		
+		schema := SchemaFromType(reflect.TypeOf(MockUUID{}))
+		
+		// With handler registered, MockUUID should be treated as UUID
+		if schema.Type != "string" {
+			t.Errorf("Expected registered MockUUID to be 'string', got '%s'", schema.Type)
+		}
+		
+		if schema.Format != "uuid" {
+			t.Errorf("Expected registered MockUUID format to be 'uuid', got '%s'", schema.Format)
+		}
+	})
+}

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -1,0 +1,375 @@
+package integration
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/joakimcarlsson/go-router/router"
+)
+
+func TestDefaultSetupOptions(t *testing.T) {
+	opts := DefaultSetupOptions()
+
+	// Test default values
+	if opts.Title != "API Documentation" {
+		t.Errorf("Expected default title 'API Documentation', got '%s'", opts.Title)
+	}
+
+	if opts.Version != "1.0.0" {
+		t.Errorf("Expected default version '1.0.0', got '%s'", opts.Version)
+	}
+
+	if opts.Description != "API documentation powered by OpenAPI and Swagger UI" {
+		t.Errorf("Expected default description, got '%s'", opts.Description)
+	}
+
+	if opts.SpecPath != "/openapi.json" {
+		t.Errorf("Expected default spec path '/openapi.json', got '%s'", opts.SpecPath)
+	}
+
+	if opts.DocsPath != "/docs" {
+		t.Errorf("Expected default docs path '/docs', got '%s'", opts.DocsPath)
+	}
+
+	if opts.DarkMode != false {
+		t.Errorf("Expected default dark mode to be false, got %t", opts.DarkMode)
+	}
+
+	// Test that boolean security options default to false
+	if opts.UseBasicAuth != false {
+		t.Errorf("Expected UseBasicAuth to default to false, got %t", opts.UseBasicAuth)
+	}
+
+	if opts.UseBearerAuth != false {
+		t.Errorf("Expected UseBearerAuth to default to false, got %t", opts.UseBearerAuth)
+	}
+
+	if opts.UseAPIKey != false {
+		t.Errorf("Expected UseAPIKey to default to false, got %t", opts.UseAPIKey)
+	}
+}
+
+func TestSetup_ValidOptions(t *testing.T) {
+	r := router.New()
+
+	opts := SetupOptions{
+		Title:       "Test API",
+		Version:     "2.0.0",
+		Description: "Test API Description",
+		SpecPath:    "/api/spec",
+		DocsPath:    "/api/docs",
+		DarkMode:    true,
+		UITitle:     "Custom UI Title",
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	// Test that routes are properly configured
+	// We can't easily test the actual route registration without exposing internals,
+	// but we can test that the function completes without error
+}
+
+func TestSetup_DefaultPaths(t *testing.T) {
+	r := router.New()
+
+	opts := SetupOptions{
+		Title:   "Test API",
+		Version: "1.0.0",
+		// Leave SpecPath and DocsPath empty to test defaults
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	// The function should use default paths when empty strings are provided
+}
+
+func TestSetup_PathConflict(t *testing.T) {
+	r := router.New()
+
+	opts := SetupOptions{
+		Title:    "Test API",
+		Version:  "1.0.0",
+		SpecPath: "/same-path",
+		DocsPath: "/same-path", // Same as spec path - should cause error
+	}
+
+	err := Setup(r, opts)
+	if err == nil {
+		t.Error("Expected error for conflicting paths, got none")
+	}
+
+	expectedError := "spec path and docs path cannot be the same: /same-path"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+	}
+}
+
+func TestSetup_WithSecuritySchemes(t *testing.T) {
+	r := router.New()
+
+	opts := SetupOptions{
+		Title:         "Test API",
+		Version:       "1.0.0",
+		UseBasicAuth:  true,
+		UseBearerAuth: true,
+		UseAPIKey:     true,
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Errorf("Expected no error with security schemes, got: %v", err)
+	}
+
+	// The function should complete successfully with all security schemes enabled
+}
+
+func TestSetup_CustomUITitle(t *testing.T) {
+	r := router.New()
+
+	opts := SetupOptions{
+		Title:   "API Title",
+		Version: "1.0.0",
+		UITitle: "Custom UI Title",
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Errorf("Expected no error with custom UI title, got: %v", err)
+	}
+}
+
+func TestSetup_NoUITitle(t *testing.T) {
+	r := router.New()
+
+	opts := SetupOptions{
+		Title:   "API Title",
+		Version: "1.0.0",
+		// UITitle is empty, should default to Title
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Errorf("Expected no error without UI title, got: %v", err)
+	}
+}
+
+func TestSetupOptions_Validation(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        SetupOptions
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid options",
+			opts: SetupOptions{
+				Title:    "Test API",
+				Version:  "1.0.0",
+				SpecPath: "/spec",
+				DocsPath: "/docs",
+			},
+			expectError: false,
+		},
+		{
+			name: "conflicting paths",
+			opts: SetupOptions{
+				Title:    "Test API",
+				Version:  "1.0.0",
+				SpecPath: "/same",
+				DocsPath: "/same",
+			},
+			expectError: true,
+			errorMsg:    "spec path and docs path cannot be the same: /same",
+		},
+		{
+			name: "empty title and version",
+			opts: SetupOptions{
+				Title:   "",
+				Version: "",
+			},
+			expectError: false, // The setup function doesn't validate required fields
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := router.New()
+			err := Setup(r, tt.opts)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if tt.expectError && err != nil && tt.errorMsg != "" {
+				if err.Error() != tt.errorMsg {
+					t.Errorf("Expected error message '%s', got '%s'", tt.errorMsg, err.Error())
+				}
+			}
+		})
+	}
+}
+
+// Integration test to verify that the setup actually works with a simple router
+func TestSetup_Integration(t *testing.T) {
+	r := router.New()
+
+	// Add a simple route to test with
+	r.GET("/users/{id}", func(c *router.Context) {
+		c.JSON(200, map[string]string{"id": c.Param("id")})
+	})
+
+	opts := SetupOptions{
+		Title:       "Integration Test API",
+		Version:     "1.0.0",
+		Description: "Test API for integration testing",
+		SpecPath:    "/openapi.json",
+		DocsPath:    "/docs",
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+	}
+
+	// Test that the main route still works
+	req := httptest.NewRequest("GET", "/users/123", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), `"id":"123"`) {
+		t.Errorf("Expected response to contain user ID, got: %s", w.Body.String())
+	}
+}
+
+// Test that Setup works with complex configuration
+func TestSetup_ComplexConfiguration(t *testing.T) {
+	r := router.New()
+
+	// Add multiple routes with different methods and patterns
+	r.GET("/users", func(c *router.Context) {
+		c.JSON(200, []string{"user1", "user2"})
+	})
+
+	r.POST("/users", func(c *router.Context) {
+		c.JSON(201, map[string]string{"status": "created"})
+	})
+
+	r.PUT("/users/{id}", func(c *router.Context) {
+		c.JSON(200, map[string]string{"id": c.Param("id"), "status": "updated"})
+	})
+
+	r.DELETE("/users/{id}", func(c *router.Context) {
+		c.Status(204)
+	})
+
+	opts := SetupOptions{
+		Title:         "Complex API",
+		Version:       "2.1.0",
+		Description:   "A complex API with multiple endpoints and security",
+		SpecPath:      "/api-spec.json",
+		DocsPath:      "/api-docs",
+		DarkMode:      true,
+		UITitle:       "Complex API Documentation",
+		UseBasicAuth:  true,
+		UseBearerAuth: true,
+		UseAPIKey:     true,
+	}
+
+	err := Setup(r, opts)
+	if err != nil {
+		t.Fatalf("Setup with complex configuration failed: %v", err)
+	}
+
+	// Test that all original routes still work
+	testCases := []struct {
+		method       string
+		path         string
+		expectedCode int
+	}{
+		{"GET", "/users", 200},
+		{"POST", "/users", 201},
+		{"PUT", "/users/456", 200},
+		{"DELETE", "/users/789", 204},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tc.expectedCode {
+				t.Errorf("Expected status %d, got %d", tc.expectedCode, w.Code)
+			}
+		})
+	}
+}
+
+// Test edge cases and error conditions
+func TestSetup_EdgeCases(t *testing.T) {
+	t.Run("nil router", func(t *testing.T) {
+		// This would panic in the actual Setup function, which is expected behavior
+		// We don't test this as it would crash the test, but it's worth noting
+		// that Setup expects a valid router instance
+	})
+
+	t.Run("empty options", func(t *testing.T) {
+		r := router.New()
+		opts := SetupOptions{} // All fields empty
+
+		err := Setup(r, opts)
+		if err != nil {
+			t.Errorf("Expected Setup to work with empty options (using defaults), got error: %v", err)
+		}
+	})
+
+	t.Run("very long paths", func(t *testing.T) {
+		r := router.New()
+		longPath := "/" + strings.Repeat("a", 1000)
+
+		opts := SetupOptions{
+			Title:    "Test API",
+			Version:  "1.0.0",
+			SpecPath: longPath + "1",
+			DocsPath: longPath + "2",
+		}
+
+		err := Setup(r, opts)
+		if err != nil {
+			t.Errorf("Expected Setup to work with long paths, got error: %v", err)
+		}
+	})
+
+	t.Run("special characters in paths", func(t *testing.T) {
+		r := router.New()
+
+		opts := SetupOptions{
+			Title:    "Test API",
+			Version:  "1.0.0",
+			SpecPath: "/api-spec.json",
+			DocsPath: "/api_docs",
+		}
+
+		err := Setup(r, opts)
+		if err != nil {
+			t.Errorf("Expected Setup to work with special characters in paths, got error: %v", err)
+		}
+	})
+}

--- a/metadata/types_test.go
+++ b/metadata/types_test.go
@@ -1,0 +1,578 @@
+package metadata
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestRouteMetadata_JSON(t *testing.T) {
+	metadata := RouteMetadata{
+		OperationID: "getUser",
+		Summary:     "Get user by ID",
+		Description: "Returns a user by their ID",
+		Tags:        []string{"Users"},
+		Deprecated:  false,
+		Parameters: []Parameter{
+			{
+				Name:     "id",
+				In:       "path",
+				Required: true,
+				Description: "User ID",
+				Schema:   Schema{Type: "string", Format: "uuid"},
+			},
+		},
+		Responses: map[string]Response{
+			"200": {
+				Description: "User found",
+				Content: map[string]MediaType{
+					ContentTypeJSON: {
+						Schema: Schema{Type: "object"},
+					},
+				},
+			},
+		},
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("Failed to marshal RouteMetadata: %v", err)
+	}
+
+	// Test JSON unmarshaling
+	var unmarshaled RouteMetadata
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal RouteMetadata: %v", err)
+	}
+
+	// Check that the unmarshaled data matches the original
+	if unmarshaled.OperationID != metadata.OperationID {
+		t.Errorf("Expected OperationID '%s', got '%s'", metadata.OperationID, unmarshaled.OperationID)
+	}
+
+	if unmarshaled.Summary != metadata.Summary {
+		t.Errorf("Expected Summary '%s', got '%s'", metadata.Summary, unmarshaled.Summary)
+	}
+
+	if len(unmarshaled.Parameters) != 1 {
+		t.Fatalf("Expected 1 parameter, got %d", len(unmarshaled.Parameters))
+	}
+
+	param := unmarshaled.Parameters[0]
+	if param.Name != "id" {
+		t.Errorf("Expected parameter name 'id', got '%s'", param.Name)
+	}
+
+	if param.In != "path" {
+		t.Errorf("Expected parameter in 'path', got '%s'", param.In)
+	}
+
+	if !param.Required {
+		t.Error("Expected parameter to be required")
+	}
+}
+
+func TestParameter_Validation(t *testing.T) {
+	tests := []struct {
+		name      string
+		parameter Parameter
+		valid     bool
+	}{
+		{
+			name: "valid path parameter",
+			parameter: Parameter{
+				Name:     "id",
+				In:       "path",
+				Required: true,
+				Schema:   Schema{Type: "string"},
+			},
+			valid: true,
+		},
+		{
+			name: "valid query parameter",
+			parameter: Parameter{
+				Name:     "limit",
+				In:       "query",
+				Required: false,
+				Schema:   Schema{Type: "integer"},
+			},
+			valid: true,
+		},
+		{
+			name: "valid header parameter",
+			parameter: Parameter{
+				Name:     "Authorization",
+				In:       "header",
+				Required: true,
+				Schema:   Schema{Type: "string"},
+			},
+			valid: true,
+		},
+		{
+			name: "valid cookie parameter",
+			parameter: Parameter{
+				Name:     "sessionId",
+				In:       "cookie",
+				Required: false,
+				Schema:   Schema{Type: "string"},
+			},
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test JSON marshaling/unmarshaling
+			jsonData, err := json.Marshal(tt.parameter)
+			if err != nil {
+				if tt.valid {
+					t.Errorf("Expected valid parameter to marshal successfully, got error: %v", err)
+				}
+				return
+			}
+
+			var unmarshaled Parameter
+			if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+				if tt.valid {
+					t.Errorf("Expected valid parameter to unmarshal successfully, got error: %v", err)
+				}
+				return
+			}
+
+			// Check that the unmarshaled data matches the original
+			if unmarshaled.Name != tt.parameter.Name {
+				t.Errorf("Expected Name '%s', got '%s'", tt.parameter.Name, unmarshaled.Name)
+			}
+
+			if unmarshaled.In != tt.parameter.In {
+				t.Errorf("Expected In '%s', got '%s'", tt.parameter.In, unmarshaled.In)
+			}
+
+			if unmarshaled.Required != tt.parameter.Required {
+				t.Errorf("Expected Required %t, got %t", tt.parameter.Required, unmarshaled.Required)
+			}
+		})
+	}
+}
+
+func TestSchema_Validation(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema Schema
+		valid  bool
+	}{
+		{
+			name: "basic string schema",
+			schema: Schema{
+				Type:     "string",
+				Format:   "uuid",
+				Example:  "123e4567-e89b-12d3-a456-426614174000",
+				TypeName: "UUID",
+			},
+			valid: true,
+		},
+		{
+			name: "integer schema with validation",
+			schema: Schema{
+				Type:     "integer",
+				Minimum:  floatPtr(1),
+				Maximum:  floatPtr(100),
+				Example:  42,
+				TypeName: "int",
+			},
+			valid: true,
+		},
+		{
+			name: "string schema with length validation",
+			schema: Schema{
+				Type:      "string",
+				MinLength: intPtr(1),
+				MaxLength: intPtr(255),
+				Example:   "example",
+				TypeName:  "string",
+			},
+			valid: true,
+		},
+		{
+			name: "object schema with properties",
+			schema: Schema{
+				Type: "object",
+				Properties: map[string]Schema{
+					"id": {
+						Type:   "string",
+						Format: "uuid",
+					},
+					"name": {
+						Type: "string",
+					},
+				},
+				Required: []string{"id", "name"},
+				TypeName: "User",
+			},
+			valid: true,
+		},
+		{
+			name: "array schema with items",
+			schema: Schema{
+				Type: "array",
+				Items: &Schema{
+					Type: "string",
+				},
+				TypeName: "[]string",
+			},
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test JSON marshaling/unmarshaling
+			jsonData, err := json.Marshal(tt.schema)
+			if err != nil {
+				if tt.valid {
+					t.Errorf("Expected valid schema to marshal successfully, got error: %v", err)
+				}
+				return
+			}
+
+			var unmarshaled Schema
+			if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+				if tt.valid {
+					t.Errorf("Expected valid schema to unmarshal successfully, got error: %v", err)
+				}
+				return
+			}
+
+			// Check basic fields
+			if unmarshaled.Type != tt.schema.Type {
+				t.Errorf("Expected Type '%s', got '%s'", tt.schema.Type, unmarshaled.Type)
+			}
+
+			if unmarshaled.Format != tt.schema.Format {
+				t.Errorf("Expected Format '%s', got '%s'", tt.schema.Format, unmarshaled.Format)
+			}
+
+			// Note: TypeName is not serialized (has json:"-" tag) as it's an internal field
+		})
+	}
+}
+
+func TestResponse_Validation(t *testing.T) {
+	response := Response{
+		Description: "Success response",
+		Headers: map[string]Header{
+			"X-Rate-Limit": {
+				Description: "Requests per hour",
+				Schema:      Schema{Type: "integer"},
+			},
+		},
+		Content: map[string]MediaType{
+			ContentTypeJSON: {
+				Schema: Schema{
+					Type: "object",
+					Properties: map[string]Schema{
+						"status": {Type: "string"},
+						"data":   {Type: "object"},
+					},
+				},
+			},
+			ContentTypeXML: {
+				Schema: Schema{
+					Type: "object",
+				},
+			},
+		},
+	}
+
+	// Test JSON marshaling/unmarshaling
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal Response: %v", err)
+	}
+
+	var unmarshaled Response
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal Response: %v", err)
+	}
+
+	// Check that the unmarshaled data matches the original
+	if unmarshaled.Description != response.Description {
+		t.Errorf("Expected Description '%s', got '%s'", response.Description, unmarshaled.Description)
+	}
+
+	if len(unmarshaled.Headers) != 1 {
+		t.Fatalf("Expected 1 header, got %d", len(unmarshaled.Headers))
+	}
+
+	if len(unmarshaled.Content) != 2 {
+		t.Fatalf("Expected 2 content types, got %d", len(unmarshaled.Content))
+	}
+
+	// Check specific content types exist
+	if _, exists := unmarshaled.Content[ContentTypeJSON]; !exists {
+		t.Error("Expected JSON content type to exist")
+	}
+
+	if _, exists := unmarshaled.Content[ContentTypeXML]; !exists {
+		t.Error("Expected XML content type to exist")
+	}
+}
+
+func TestRequestBody_Validation(t *testing.T) {
+	requestBody := RequestBody{
+		Description: "User data",
+		Required:    true,
+		Content: map[string]MediaType{
+			ContentTypeJSON: {
+				Schema: Schema{
+					Type: "object",
+					Properties: map[string]Schema{
+						"name":  {Type: "string"},
+						"email": {Type: "string", Format: "email"},
+					},
+					Required: []string{"name", "email"},
+				},
+			},
+			ContentTypeFormData: {
+				Schema: Schema{
+					Type: "object",
+					Properties: map[string]Schema{
+						"name":  {Type: "string"},
+						"email": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	// Test JSON marshaling/unmarshaling
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal RequestBody: %v", err)
+	}
+
+	var unmarshaled RequestBody
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal RequestBody: %v", err)
+	}
+
+	// Check that the unmarshaled data matches the original
+	if unmarshaled.Description != requestBody.Description {
+		t.Errorf("Expected Description '%s', got '%s'", requestBody.Description, unmarshaled.Description)
+	}
+
+	if unmarshaled.Required != requestBody.Required {
+		t.Errorf("Expected Required %t, got %t", requestBody.Required, unmarshaled.Required)
+	}
+
+	if len(unmarshaled.Content) != 2 {
+		t.Fatalf("Expected 2 content types, got %d", len(unmarshaled.Content))
+	}
+}
+
+func TestSecurityRequirement_Validation(t *testing.T) {
+	securityReq := SecurityRequirement{
+		"apiKey": []string{"read", "write"},
+		"oauth2": []string{"user:read", "user:write"},
+	}
+
+	// Test JSON marshaling/unmarshaling
+	jsonData, err := json.Marshal(securityReq)
+	if err != nil {
+		t.Fatalf("Failed to marshal SecurityRequirement: %v", err)
+	}
+
+	var unmarshaled SecurityRequirement
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal SecurityRequirement: %v", err)
+	}
+
+	// Check that the unmarshaled data matches the original
+	if len(unmarshaled) != 2 {
+		t.Fatalf("Expected 2 security schemes, got %d", len(unmarshaled))
+	}
+
+	apiKeyScopes, exists := unmarshaled["apiKey"]
+	if !exists {
+		t.Error("Expected apiKey security scheme to exist")
+	} else if len(apiKeyScopes) != 2 {
+		t.Errorf("Expected 2 apiKey scopes, got %d", len(apiKeyScopes))
+	}
+
+	oauth2Scopes, exists := unmarshaled["oauth2"]
+	if !exists {
+		t.Error("Expected oauth2 security scheme to exist")
+	} else if len(oauth2Scopes) != 2 {
+		t.Errorf("Expected 2 oauth2 scopes, got %d", len(oauth2Scopes))
+	}
+}
+
+func TestInfo_Validation(t *testing.T) {
+	info := Info{
+		Title:          "Test API",
+		Version:        "1.0.0",
+		Description:    "A test API",
+		TermsOfService: "https://example.com/terms",
+		Contact: &Contact{
+			Name:  "API Support",
+			URL:   "https://example.com/contact",
+			Email: "support@example.com",
+		},
+		License: &License{
+			Name: "MIT",
+			URL:  "https://opensource.org/licenses/MIT",
+		},
+	}
+
+	// Test JSON marshaling/unmarshaling
+	jsonData, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("Failed to marshal Info: %v", err)
+	}
+
+	var unmarshaled Info
+	if err := json.Unmarshal(jsonData, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal Info: %v", err)
+	}
+
+	// Check that the unmarshaled data matches the original
+	if unmarshaled.Title != info.Title {
+		t.Errorf("Expected Title '%s', got '%s'", info.Title, unmarshaled.Title)
+	}
+
+	if unmarshaled.Version != info.Version {
+		t.Errorf("Expected Version '%s', got '%s'", info.Version, unmarshaled.Version)
+	}
+
+	if unmarshaled.Description != info.Description {
+		t.Errorf("Expected Description '%s', got '%s'", info.Description, unmarshaled.Description)
+	}
+
+	if unmarshaled.Contact == nil {
+		t.Error("Expected Contact to exist")
+	} else {
+		if unmarshaled.Contact.Name != info.Contact.Name {
+			t.Errorf("Expected Contact Name '%s', got '%s'", info.Contact.Name, unmarshaled.Contact.Name)
+		}
+	}
+
+	if unmarshaled.License == nil {
+		t.Error("Expected License to exist")
+	} else {
+		if unmarshaled.License.Name != info.License.Name {
+			t.Errorf("Expected License Name '%s', got '%s'", info.License.Name, unmarshaled.License.Name)
+		}
+	}
+}
+
+func TestTypeHandlerRegistry(t *testing.T) {
+	// Test registering a new type handler
+	typeName := "test.CustomType"
+	handler := func(t reflect.Type) Schema {
+		return Schema{
+			Type:     "string",
+			Format:   "custom",
+			TypeName: "CustomType",
+		}
+	}
+
+	RegisterTypeHandler(typeName, handler)
+
+	// Test retrieving the handler
+	retrievedHandler, exists := GetTypeHandler(typeName)
+	if !exists {
+		t.Error("Expected type handler to exist after registration")
+	}
+
+	// Test that the handler works correctly
+	testType := reflect.TypeOf("")
+	schema := retrievedHandler(testType)
+	if schema.Type != "string" {
+		t.Errorf("Expected schema type 'string', got '%s'", schema.Type)
+	}
+
+	if schema.Format != "custom" {
+		t.Errorf("Expected schema format 'custom', got '%s'", schema.Format)
+	}
+
+	if schema.TypeName != "CustomType" {
+		t.Errorf("Expected schema TypeName 'CustomType', got '%s'", schema.TypeName)
+	}
+
+	// Test retrieving non-existent handler
+	_, exists = GetTypeHandler("nonexistent.Type")
+	if exists {
+		t.Error("Expected non-existent type handler to not exist")
+	}
+}
+
+func TestTypeRegistry(t *testing.T) {
+	// Test registering a new type
+	type TestStruct struct {
+		Name string
+	}
+
+	testType := reflect.TypeOf(TestStruct{})
+	registeredName := RegisterType(testType)
+
+	if registeredName == "" {
+		t.Error("Expected non-empty registered name")
+	}
+
+	// The registered name should be based on the type name
+	if registeredName != "TestStruct" {
+		t.Errorf("Expected registered name 'TestStruct', got '%s'", registeredName)
+	}
+
+	// Test registering the same type again (should return the same name)
+	registeredName2 := RegisterType(testType)
+	if registeredName2 != registeredName {
+		t.Errorf("Expected same registered name '%s', got '%s'", registeredName, registeredName2)
+	}
+
+	// Test registering anonymous struct (name will be empty since t.Name() returns empty for anonymous structs)
+	anonymousType := reflect.TypeOf(struct{ Value int }{})
+	anonymousName := RegisterType(anonymousType)
+	// Anonymous structs have empty Name(), so RegisterType returns empty string
+	// This is expected behavior as anonymous structs don't have a type name
+	if anonymousType.Name() == "" && anonymousName == "" {
+		// This is expected - anonymous structs don't have names
+	} else if anonymousName == "" && anonymousType.Name() != "" {
+		t.Error("Expected non-empty name for named struct type")
+	}
+}
+
+func TestConstantValues(t *testing.T) {
+	// Test that content type constants have expected values
+	expectedConstants := map[string]string{
+		"ContentTypeJSON":        "application/json",
+		"ContentTypeXML":         "application/xml",
+		"ContentTypeEventStream": "text/event-stream",
+		"ContentTypeHTML":        "text/html",
+		"ContentTypeFormData":    "multipart/form-data",
+	}
+
+	actualConstants := map[string]string{
+		"ContentTypeJSON":        ContentTypeJSON,
+		"ContentTypeXML":         ContentTypeXML,
+		"ContentTypeEventStream": ContentTypeEventStream,
+		"ContentTypeHTML":        ContentTypeHTML,
+		"ContentTypeFormData":    ContentTypeFormData,
+	}
+
+	for name, expected := range expectedConstants {
+		if actual := actualConstants[name]; actual != expected {
+			t.Errorf("Expected %s to be '%s', got '%s'", name, expected, actual)
+		}
+	}
+}
+
+// Helper functions for creating pointers to primitive types
+func intPtr(i int) *int {
+	return &i
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -1,0 +1,437 @@
+package openapi
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/joakimcarlsson/go-router/metadata"
+)
+
+// MockUUID mimics uuid.UUID structure ([16]byte array) without external dependency
+type MockUUID [16]byte
+
+// String implements the same interface as uuid.UUID for testing
+func (u MockUUID) String() string {
+	return "123e4567-e89b-12d3-a456-426614174000"
+}
+
+// Test types for OpenAPI generation
+type APIUser struct {
+	ID      MockUUID   `json:"id"`
+	Name    string     `json:"name" validate:"required"`
+	Email   *string    `json:"email"`
+	Created time.Time  `json:"created"`
+	Updated *time.Time `json:"updated"`
+}
+
+type APIProduct struct {
+	ID    MockUUID `json:"id"`
+	Name  string   `json:"name"`
+	Price float64  `json:"price"`
+}
+
+// MockRouteInfo implements RouteInfo interface for testing
+type MockRouteInfo struct {
+	method      string
+	path        string
+	operationID string
+	summary     string
+	description string
+	tags        []string
+	parameters  []metadata.Parameter
+	requestBody *metadata.RequestBody
+	responses   map[string]metadata.Response
+	security    []metadata.SecurityRequirement
+	deprecated  bool
+}
+
+func (m *MockRouteInfo) Method() string                           { return m.method }
+func (m *MockRouteInfo) Path() string                             { return m.path }
+func (m *MockRouteInfo) OperationID() string                      { return m.operationID }
+func (m *MockRouteInfo) Summary() string                          { return m.summary }
+func (m *MockRouteInfo) Description() string                      { return m.description }
+func (m *MockRouteInfo) Tags() []string                           { return m.tags }
+func (m *MockRouteInfo) Parameters() []metadata.Parameter         { return m.parameters }
+func (m *MockRouteInfo) RequestBody() *metadata.RequestBody       { return m.requestBody }
+func (m *MockRouteInfo) Responses() map[string]metadata.Response  { return m.responses }
+func (m *MockRouteInfo) Security() []metadata.SecurityRequirement { return m.security }
+func (m *MockRouteInfo) IsDeprecated() bool                       { return m.deprecated }
+
+func setupMockUUID() {
+	// Register MockUUID to behave like real uuid.UUID for all tests
+	metadata.RegisterTypeHandler("openapi.MockUUID", func(t reflect.Type) metadata.Schema {
+		return metadata.Schema{
+			Type:     "string",
+			Format:   "uuid",
+			Example:  "123e4567-e89b-12d3-a456-426614174000",
+			TypeName: "UUID",
+		}
+	})
+}
+
+func TestWithResponseType_UUID(t *testing.T) {
+	setupMockUUID()
+
+	// Test that WithResponseType correctly handles UUID fields
+	var routeMetadata metadata.RouteMetadata
+
+	// Apply the route option
+	option := WithResponseType(200, "User details", APIUser{})
+	option(&routeMetadata)
+
+	// Check that responses were created
+	if routeMetadata.Responses == nil {
+		t.Fatal("Expected responses to be created")
+	}
+
+	response, exists := routeMetadata.Responses["200"]
+	if !exists {
+		t.Fatal("Expected 200 response to exist")
+	}
+
+	if response.Description != "User details" {
+		t.Errorf("Expected response description to be 'User details', got '%s'", response.Description)
+	}
+
+	// Check JSON content
+	jsonContent, exists := response.Content["application/json"]
+	if !exists {
+		t.Fatal("Expected JSON content to exist")
+	}
+
+	// The schema should use a reference for object types
+	if jsonContent.SchemaRef == nil {
+		t.Fatal("Expected schema reference for object type")
+	}
+
+	expectedRef := "#/components/schemas/APIUser"
+	if jsonContent.SchemaRef.Ref != expectedRef {
+		t.Errorf("Expected schema reference to be '%s', got '%s'", expectedRef, jsonContent.SchemaRef.Ref)
+	}
+}
+
+func TestWithJSONResponseAdvanced_SliceOfUUID(t *testing.T) {
+	setupMockUUID()
+
+	// Test that arrays of UUID work correctly
+	var routeMetadata metadata.RouteMetadata
+
+	// Apply the route option for slice of APIUser
+	option := WithJSONResponseAdvanced[[]APIUser](200, "List of users")
+	option(&routeMetadata)
+
+	// Check that responses were created
+	if routeMetadata.Responses == nil {
+		t.Fatal("Expected responses to be created")
+	}
+
+	response, exists := routeMetadata.Responses["200"]
+	if !exists {
+		t.Fatal("Expected 200 response to exist")
+	}
+
+	// Check JSON content
+	jsonContent, exists := response.Content["application/json"]
+	if !exists {
+		t.Fatal("Expected JSON content to exist")
+	}
+
+	// For array types, the schema should be inline with items reference
+	if jsonContent.Schema.Type != "array" {
+		t.Errorf("Expected schema type to be 'array', got '%s'", jsonContent.Schema.Type)
+	}
+
+	if jsonContent.Schema.Items == nil {
+		t.Fatal("Expected array schema to have items")
+	}
+
+	expectedRef := "#/components/schemas/APIUser"
+	if jsonContent.Schema.Items.Ref != expectedRef {
+		t.Errorf("Expected items reference to be '%s', got '%s'", expectedRef, jsonContent.Schema.Items.Ref)
+	}
+}
+
+func TestWithRequestBody_UUID(t *testing.T) {
+	setupMockUUID()
+
+	// Test that request body with UUID works correctly
+	var routeMetadata metadata.RouteMetadata
+
+	// Apply the route option
+	option := WithRequestBody("User data", true, APIUser{})
+	option(&routeMetadata)
+
+	// Check that request body was created
+	if routeMetadata.RequestBody == nil {
+		t.Fatal("Expected request body to be created")
+	}
+
+	if routeMetadata.RequestBody.Description != "User data" {
+		t.Errorf("Expected request body description to be 'User data', got '%s'", routeMetadata.RequestBody.Description)
+	}
+
+	if !routeMetadata.RequestBody.Required {
+		t.Error("Expected request body to be required")
+	}
+
+	// Check JSON content
+	jsonContent, exists := routeMetadata.RequestBody.Content["application/json"]
+	if !exists {
+		t.Fatal("Expected JSON content to exist")
+	}
+
+	// Check that the schema has UUID field correctly typed
+	if jsonContent.Schema.Type != "object" {
+		t.Errorf("Expected schema type to be 'object', got '%s'", jsonContent.Schema.Type)
+	}
+
+	if jsonContent.Schema.Properties == nil {
+		t.Fatal("Expected schema to have properties")
+	}
+
+	idProp, exists := jsonContent.Schema.Properties["id"]
+	if !exists {
+		t.Fatal("Expected schema to have 'id' property")
+	}
+
+	if idProp.Type != "string" {
+		t.Errorf("Expected id type to be 'string', got '%s'", idProp.Type)
+	}
+
+	if idProp.Format != "uuid" {
+		t.Errorf("Expected id format to be 'uuid', got '%s'", idProp.Format)
+	}
+}
+
+func TestWithResponseExample_UUID(t *testing.T) {
+	setupMockUUID()
+
+	// Test that response examples work with UUID
+	var routeMetadata metadata.RouteMetadata
+
+	// Create a MockUUID with the expected value
+	var mockID MockUUID
+	copy(mockID[:], []byte("123e4567-e89b-12d3")) // Fill with some bytes for testing
+
+	exampleUser := APIUser{
+		ID:      mockID,
+		Name:    "John Doe",
+		Email:   nil,
+		Created: time.Now(),
+		Updated: nil,
+	}
+
+	// Apply the route option
+	option := WithResponseExample(200, "User example", exampleUser)
+	option(&routeMetadata)
+
+	// Check that responses were created
+	if routeMetadata.Responses == nil {
+		t.Fatal("Expected responses to be created")
+	}
+
+	response, exists := routeMetadata.Responses["200"]
+	if !exists {
+		t.Fatal("Expected 200 response to exist")
+	}
+
+	// Check JSON content
+	jsonContent, exists := response.Content["application/json"]
+	if !exists {
+		t.Fatal("Expected JSON content to exist")
+	}
+
+	// Check that example is set
+	if jsonContent.Schema.Example == nil {
+		t.Fatal("Expected schema to have example")
+	}
+
+	// Verify the example is the struct we provided
+	exampleUser2, ok := jsonContent.Schema.Example.(APIUser)
+	if !ok {
+		t.Fatal("Expected example to be an APIUser struct")
+	}
+
+	// The ID should be the example UUID we set
+	if exampleUser2.ID != exampleUser.ID {
+		t.Errorf("Expected example id to be '%v', got '%v'", exampleUser.ID, exampleUser2.ID)
+	}
+
+	if exampleUser2.Name != exampleUser.Name {
+		t.Errorf("Expected example name to be '%s', got '%s'", exampleUser.Name, exampleUser2.Name)
+	}
+}
+
+func TestGenerator_Generate_WithUUID(t *testing.T) {
+	setupMockUUID()
+
+	// Test full OpenAPI generation with UUID types
+	generator := NewGenerator(metadata.Info{
+		Title:   "Test API",
+		Version: "1.0.0",
+	})
+
+	// Create a mock route with UUID response
+	routes := []RouteInfo{
+		&MockRouteInfo{
+			method:      "GET",
+			path:        "/users/{id}",
+			operationID: "getUser",
+			summary:     "Get user by ID",
+			description: "Returns a user by their ID",
+			tags:        []string{"Users"},
+			parameters: []metadata.Parameter{
+				{
+					Name:     "id",
+					In:       "path",
+					Required: true,
+					Schema: metadata.Schema{
+						Type:   "string",
+						Format: "uuid",
+					},
+				},
+			},
+			responses: map[string]metadata.Response{
+				"200": {
+					Description: "User found",
+					Content: map[string]metadata.MediaType{
+						"application/json": {
+							SchemaRef: &metadata.Reference{
+								Ref: "#/components/schemas/APIUser",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Generate the spec
+	spec := generator.Generate(routes)
+
+	// Check basic structure
+	if spec.OpenAPI != "3.0.0" {
+		t.Errorf("Expected OpenAPI version to be '3.0.0', got '%s'", spec.OpenAPI)
+	}
+
+	if spec.Info.Title != "Test API" {
+		t.Errorf("Expected title to be 'Test API', got '%s'", spec.Info.Title)
+	}
+
+	// Check paths
+	if spec.Paths == nil {
+		t.Fatal("Expected paths to exist")
+	}
+
+	pathItem, exists := spec.Paths["/users/{id}"]
+	if !exists {
+		t.Fatal("Expected /users/{id} path to exist")
+	}
+
+	if pathItem.Get == nil {
+		t.Fatal("Expected GET operation to exist")
+	}
+
+	// Check operation
+	operation := pathItem.Get
+	if operation.OperationID != "getUser" {
+		t.Errorf("Expected operation ID to be 'getUser', got '%s'", operation.OperationID)
+	}
+
+	// Check parameters
+	if len(operation.Parameters) != 1 {
+		t.Fatalf("Expected 1 parameter, got %d", len(operation.Parameters))
+	}
+
+	param := operation.Parameters[0]
+	if param.Name != "id" {
+		t.Errorf("Expected parameter name to be 'id', got '%s'", param.Name)
+	}
+
+	if param.Schema.Format != "uuid" {
+		t.Errorf("Expected parameter format to be 'uuid', got '%s'", param.Schema.Format)
+	}
+
+	// Check responses
+	response, exists := operation.Responses["200"]
+	if !exists {
+		t.Fatal("Expected 200 response to exist")
+	}
+
+	jsonContent, exists := response.Content["application/json"]
+	if !exists {
+		t.Fatal("Expected JSON content to exist")
+	}
+
+	if jsonContent.SchemaRef == nil {
+		t.Fatal("Expected schema reference")
+	}
+
+	expectedRef := "#/components/schemas/APIUser"
+	if jsonContent.SchemaRef.Ref != expectedRef {
+		t.Errorf("Expected schema reference to be '%s', got '%s'", expectedRef, jsonContent.SchemaRef.Ref)
+	}
+}
+
+func TestWithEmptyResponse(t *testing.T) {
+	// Test simple response without content
+	var routeMetadata metadata.RouteMetadata
+
+	option := WithEmptyResponse(204, "No content")
+	option(&routeMetadata)
+
+	if routeMetadata.Responses == nil {
+		t.Fatal("Expected responses to be created")
+	}
+
+	response, exists := routeMetadata.Responses["204"]
+	if !exists {
+		t.Fatal("Expected 204 response to exist")
+	}
+
+	if response.Description != "No content" {
+		t.Errorf("Expected response description to be 'No content', got '%s'", response.Description)
+	}
+
+	// Empty response should have no content
+	if len(response.Content) > 0 {
+		t.Error("Expected empty response to have no content")
+	}
+}
+
+func TestWithResponseSchema(t *testing.T) {
+	// Test response with custom schema
+	var routeMetadata metadata.RouteMetadata
+
+	customSchema := metadata.Schema{
+		Type:    "string",
+		Format:  "uuid",
+		Example: "123e4567-e89b-12d3-a456-426614174000",
+	}
+
+	option := WithResponseSchema(200, "Custom UUID", "application/json", customSchema)
+	option(&routeMetadata)
+
+	if routeMetadata.Responses == nil {
+		t.Fatal("Expected responses to be created")
+	}
+
+	response, exists := routeMetadata.Responses["200"]
+	if !exists {
+		t.Fatal("Expected 200 response to exist")
+	}
+
+	jsonContent, exists := response.Content["application/json"]
+	if !exists {
+		t.Fatal("Expected JSON content to exist")
+	}
+
+	if jsonContent.Schema.Type != "string" {
+		t.Errorf("Expected schema type to be 'string', got '%s'", jsonContent.Schema.Type)
+	}
+
+	if jsonContent.Schema.Format != "uuid" {
+		t.Errorf("Expected schema format to be 'uuid', got '%s'", jsonContent.Schema.Format)
+	}
+}

--- a/router/context_test.go
+++ b/router/context_test.go
@@ -1,0 +1,839 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test types for binding tests
+type User struct {
+	ID    int    `json:"id" xml:"id" form:"id"`
+	Name  string `json:"name" xml:"name" form:"name"`
+	Email string `json:"email" xml:"email" form:"email"`
+}
+
+type FileUpload struct {
+	File        *multipart.FileHeader `form:"file" file:"true"`
+	Name        string                `form:"name"`
+	Description string                `form:"description"`
+}
+
+func TestContext_Query(t *testing.T) {
+	req := httptest.NewRequest("GET", "/?name=john&age=25&active=true", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	// Test basic query retrieval
+	query := ctx.Query()
+	if query.Get("name") != "john" {
+		t.Errorf("Expected name to be 'john', got '%s'", query.Get("name"))
+	}
+}
+
+func TestContext_QueryDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		key          string
+		defaultValue string
+		expected     string
+	}{
+		{
+			name:         "existing parameter",
+			url:          "/?name=john",
+			key:          "name",
+			defaultValue: "default",
+			expected:     "john",
+		},
+		{
+			name:         "missing parameter",
+			url:          "/?other=value",
+			key:          "name",
+			defaultValue: "default",
+			expected:     "default",
+		},
+		{
+			name:         "empty parameter value",
+			url:          "/?name=",
+			key:          "name",
+			defaultValue: "default",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result := ctx.QueryDefault(tt.key, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("Expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_QueryInt(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		key         string
+		expected    int
+		expectError bool
+	}{
+		{
+			name:        "valid integer",
+			url:         "/?age=25",
+			key:         "age",
+			expected:    25,
+			expectError: false,
+		},
+		{
+			name:        "invalid integer",
+			url:         "/?age=abc",
+			key:         "age",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "missing parameter",
+			url:         "/?other=value",
+			key:         "age",
+			expected:    0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result, err := ctx.QueryInt(tt.key)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+			if !tt.expectError && result != tt.expected {
+				t.Errorf("Expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_QueryIntDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		key          string
+		defaultValue int
+		expected     int
+	}{
+		{
+			name:         "valid integer",
+			url:          "/?age=25",
+			key:          "age",
+			defaultValue: 30,
+			expected:     25,
+		},
+		{
+			name:         "invalid integer uses default",
+			url:          "/?age=abc",
+			key:          "age",
+			defaultValue: 30,
+			expected:     30,
+		},
+		{
+			name:         "missing parameter uses default",
+			url:          "/?other=value",
+			key:          "age",
+			defaultValue: 30,
+			expected:     30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result := ctx.QueryIntDefault(tt.key, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("Expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_QueryBool(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		key         string
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:        "true value",
+			url:         "/?active=true",
+			key:         "active",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "false value",
+			url:         "/?active=false",
+			key:         "active",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "1 value",
+			url:         "/?active=1",
+			key:         "active",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "0 value",
+			url:         "/?active=0",
+			key:         "active",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "invalid boolean",
+			url:         "/?active=maybe",
+			key:         "active",
+			expected:    false,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result, err := ctx.QueryBool(tt.key)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+			if !tt.expectError && result != tt.expected {
+				t.Errorf("Expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_QueryBoolDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		key          string
+		defaultValue bool
+		expected     bool
+	}{
+		{
+			name:         "valid true",
+			url:          "/?active=true",
+			key:          "active",
+			defaultValue: false,
+			expected:     true,
+		},
+		{
+			name:         "valid false",
+			url:          "/?active=false",
+			key:          "active",
+			defaultValue: true,
+			expected:     false,
+		},
+		{
+			name:         "invalid boolean uses default",
+			url:          "/?active=maybe",
+			key:          "active",
+			defaultValue: true,
+			expected:     true,
+		},
+		{
+			name:         "missing parameter uses default",
+			url:          "/?other=value",
+			key:          "active",
+			defaultValue: true,
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result := ctx.QueryBoolDefault(tt.key, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("Expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_Param(t *testing.T) {
+	// Create a test request with path parameters
+	req := httptest.NewRequest("GET", "/users/123", nil)
+	req.SetPathValue("id", "123")
+	req.SetPathValue("name", "john")
+
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	// Test existing parameter
+	if ctx.Param("id") != "123" {
+		t.Errorf("Expected id to be '123', got '%s'", ctx.Param("id"))
+	}
+
+	if ctx.Param("name") != "john" {
+		t.Errorf("Expected name to be 'john', got '%s'", ctx.Param("name"))
+	}
+
+	// Test missing parameter
+	if ctx.Param("missing") != "" {
+		t.Errorf("Expected missing param to be empty, got '%s'", ctx.Param("missing"))
+	}
+
+	// Test with nil request
+	ctx.Request = nil
+	if ctx.Param("id") != "" {
+		t.Errorf("Expected empty string when request is nil, got '%s'", ctx.Param("id"))
+	}
+}
+
+func TestContext_ParamInt(t *testing.T) {
+	tests := []struct {
+		name        string
+		paramValue  string
+		key         string
+		expected    int
+		expectError bool
+	}{
+		{
+			name:        "valid integer",
+			paramValue:  "123",
+			key:         "id",
+			expected:    123,
+			expectError: false,
+		},
+		{
+			name:        "invalid integer",
+			paramValue:  "abc",
+			key:         "id",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "empty parameter",
+			paramValue:  "",
+			key:         "id",
+			expected:    0,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.SetPathValue(tt.key, tt.paramValue)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result, err := ctx.ParamInt(tt.key)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+			if !tt.expectError && result != tt.expected {
+				t.Errorf("Expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_ParamIntDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		paramValue   string
+		key          string
+		defaultValue int
+		expected     int
+	}{
+		{
+			name:         "valid integer",
+			paramValue:   "123",
+			key:          "id",
+			defaultValue: 456,
+			expected:     123,
+		},
+		{
+			name:         "invalid integer uses default",
+			paramValue:   "abc",
+			key:          "id",
+			defaultValue: 456,
+			expected:     456,
+		},
+		{
+			name:         "empty parameter uses default",
+			paramValue:   "",
+			key:          "id",
+			defaultValue: 456,
+			expected:     456,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.SetPathValue(tt.key, tt.paramValue)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result := ctx.ParamIntDefault(tt.key, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("Expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_ParamBool(t *testing.T) {
+	tests := []struct {
+		name        string
+		paramValue  string
+		key         string
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:        "true value",
+			paramValue:  "true",
+			key:         "active",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "false value",
+			paramValue:  "false",
+			key:         "active",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "invalid boolean",
+			paramValue:  "maybe",
+			key:         "active",
+			expected:    false,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.SetPathValue(tt.key, tt.paramValue)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result, err := ctx.ParamBool(tt.key)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+			if !tt.expectError && result != tt.expected {
+				t.Errorf("Expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_ParamBoolDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		paramValue   string
+		key          string
+		defaultValue bool
+		expected     bool
+	}{
+		{
+			name:         "valid true",
+			paramValue:   "true",
+			key:          "active",
+			defaultValue: false,
+			expected:     true,
+		},
+		{
+			name:         "valid false",
+			paramValue:   "false",
+			key:          "active",
+			defaultValue: true,
+			expected:     false,
+		},
+		{
+			name:         "invalid boolean uses default",
+			paramValue:   "maybe",
+			key:          "active",
+			defaultValue: true,
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.SetPathValue(tt.key, tt.paramValue)
+			w := httptest.NewRecorder()
+			ctx := newContext(w, req, time.Now())
+
+			result := ctx.ParamBoolDefault(tt.key, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("Expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestContext_JSON(t *testing.T) {
+	user := User{ID: 1, Name: "John", Email: "john@example.com"}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.JSON(200, user)
+
+	// Check status code
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+
+	// Check content type
+	expectedContentType := "application/json; charset=utf-8"
+	if w.Header().Get("Content-Type") != expectedContentType {
+		t.Errorf("Expected Content-Type '%s', got '%s'", expectedContentType, w.Header().Get("Content-Type"))
+	}
+
+	// Check response body
+	var responseUser User
+	if err := json.Unmarshal(w.Body.Bytes(), &responseUser); err != nil {
+		t.Errorf("Failed to unmarshal response: %v", err)
+	}
+
+	if responseUser != user {
+		t.Errorf("Expected %+v, got %+v", user, responseUser)
+	}
+}
+
+func TestContext_JSON_Error(t *testing.T) {
+	// Test with a type that can't be marshaled to JSON (channel)
+	invalidData := make(chan int)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.JSON(200, invalidData)
+
+	// Should return 500 status code due to marshal error
+	if w.Code != 500 {
+		t.Errorf("Expected status code 500, got %d", w.Code)
+	}
+}
+
+func TestContext_XML(t *testing.T) {
+	user := User{ID: 1, Name: "John", Email: "john@example.com"}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.XML(200, user)
+
+	// Check status code
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+
+	// Check content type
+	expectedContentType := "application/xml; charset=utf-8"
+	if w.Header().Get("Content-Type") != expectedContentType {
+		t.Errorf("Expected Content-Type '%s', got '%s'", expectedContentType, w.Header().Get("Content-Type"))
+	}
+
+	// Check response body
+	var responseUser User
+	if err := xml.Unmarshal(w.Body.Bytes(), &responseUser); err != nil {
+		t.Errorf("Failed to unmarshal response: %v", err)
+	}
+
+	if responseUser != user {
+		t.Errorf("Expected %+v, got %+v", user, responseUser)
+	}
+}
+
+func TestContext_Data(t *testing.T) {
+	data := []byte("Hello, World!")
+	contentType := "text/plain"
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.Data(200, contentType, data)
+
+	// Check status code
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+
+	// Check content type
+	if w.Header().Get("Content-Type") != contentType {
+		t.Errorf("Expected Content-Type '%s', got '%s'", contentType, w.Header().Get("Content-Type"))
+	}
+
+	// Check response body
+	if !bytes.Equal(w.Body.Bytes(), data) {
+		t.Errorf("Expected body '%s', got '%s'", string(data), w.Body.String())
+	}
+}
+
+func TestContext_File(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := os.CreateTemp("", "test*.txt")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	testContent := "Hello, World!"
+	if _, err := tempFile.WriteString(testContent); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	tempFile.Close()
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.File(tempFile.Name())
+
+	// Check response body
+	if w.Body.String() != testContent {
+		t.Errorf("Expected body '%s', got '%s'", testContent, w.Body.String())
+	}
+}
+
+func TestContext_Redirect(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.Redirect(302, "/new-location")
+
+	// Check status code
+	if w.Code != 302 {
+		t.Errorf("Expected status code 302, got %d", w.Code)
+	}
+
+	// Check location header
+	expectedLocation := "/new-location"
+	if w.Header().Get("Location") != expectedLocation {
+		t.Errorf("Expected Location header '%s', got '%s'", expectedLocation, w.Header().Get("Location"))
+	}
+}
+
+func TestContext_Error(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	errorMessage := "Something went wrong"
+	ctx.Error(500, errorMessage)
+
+	// Check status code
+	if w.Code != 500 {
+		t.Errorf("Expected status code 500, got %d", w.Code)
+	}
+
+	// Check response body
+	expectedBody := errorMessage + "\n" // http.Error adds a newline
+	if w.Body.String() != expectedBody {
+		t.Errorf("Expected body '%s', got '%s'", expectedBody, w.Body.String())
+	}
+}
+
+func TestContext_Status(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.Status(201)
+
+	// Check status code
+	if w.Code != 201 {
+		t.Errorf("Expected status code 201, got %d", w.Code)
+	}
+
+	// Check that the context stores the status code
+	if ctx.StatusCode != 201 {
+		t.Errorf("Expected context status code 201, got %d", ctx.StatusCode)
+	}
+}
+
+func TestContext_GetHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer token123")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	// Test existing headers
+	if ctx.GetHeader("Authorization") != "Bearer token123" {
+		t.Errorf("Expected Authorization header 'Bearer token123', got '%s'", ctx.GetHeader("Authorization"))
+	}
+
+	if ctx.GetHeader("Content-Type") != "application/json" {
+		t.Errorf("Expected Content-Type header 'application/json', got '%s'", ctx.GetHeader("Content-Type"))
+	}
+
+	// Test missing header
+	if ctx.GetHeader("X-Missing") != "" {
+		t.Errorf("Expected missing header to be empty, got '%s'", ctx.GetHeader("X-Missing"))
+	}
+}
+
+func TestContext_SetHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	ctx.SetHeader("X-Custom", "custom-value")
+	ctx.SetHeader("Cache-Control", "no-cache")
+
+	// Check that headers were set
+	if w.Header().Get("X-Custom") != "custom-value" {
+		t.Errorf("Expected X-Custom header 'custom-value', got '%s'", w.Header().Get("X-Custom"))
+	}
+
+	if w.Header().Get("Cache-Control") != "no-cache" {
+		t.Errorf("Expected Cache-Control header 'no-cache', got '%s'", w.Header().Get("Cache-Control"))
+	}
+}
+
+func TestContext_BindJSON(t *testing.T) {
+	user := User{ID: 1, Name: "John", Email: "john@example.com"}
+	jsonData, _ := json.Marshal(user)
+
+	req := httptest.NewRequest("POST", "/", bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	var boundUser User
+	if err := ctx.BindJSON(&boundUser); err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if boundUser != user {
+		t.Errorf("Expected %+v, got %+v", user, boundUser)
+	}
+}
+
+func TestContext_BindJSON_Error(t *testing.T) {
+	// Invalid JSON
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"invalid": json}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	var user User
+	if err := ctx.BindJSON(&user); err == nil {
+		t.Error("Expected error for invalid JSON, got none")
+	}
+}
+
+func TestContext_BindXML(t *testing.T) {
+	user := User{ID: 1, Name: "John", Email: "john@example.com"}
+	xmlData, _ := xml.Marshal(user)
+
+	req := httptest.NewRequest("POST", "/", bytes.NewBuffer(xmlData))
+	req.Header.Set("Content-Type", "application/xml")
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	var boundUser User
+	if err := ctx.BindXML(&boundUser); err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if boundUser != user {
+		t.Errorf("Expected %+v, got %+v", user, boundUser)
+	}
+}
+
+func TestContext_BindForm(t *testing.T) {
+	form := url.Values{}
+	form.Set("id", "1")
+	form.Set("name", "John")
+	form.Set("email", "john@example.com")
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	ctx := newContext(w, req, time.Now())
+
+	var user User
+	if err := ctx.BindForm(&user); err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	expectedUser := User{ID: 1, Name: "John", Email: "john@example.com"}
+	if user != expectedUser {
+		t.Errorf("Expected %+v, got %+v", expectedUser, user)
+	}
+}
+
+// Helper function to create a context instance for testing
+// This mirrors the newContext function from the router package
+func newContext(w http.ResponseWriter, r *http.Request, startTime time.Time) *Context {
+	ctx := &Context{
+		Writer:             w,
+		Request:            r,
+		StartTime:          startTime,
+		StatusCode:         200,
+		store:              make(map[string]interface{}),
+		maxMultipartMemory: 32 << 20, // 32 MB
+	}
+	return ctx
+}

--- a/router/middleware/cors/cors_test.go
+++ b/router/middleware/cors/cors_test.go
@@ -16,10 +16,8 @@ func TestCORSDefault(t *testing.T) {
 		c.Writer.Write([]byte("OK"))
 	})
 
-	// Add OPTIONS handler to match the router's behavior
-	r.Handle("OPTIONS /", func(c *router.Context) {
-		// This should never be called with default CORS middleware
-	})
+	// Auto-register OPTIONS handlers for all registered routes
+	r.AutoRegisterOptions()
 
 	// Test simple request with Origin header
 	req := httptest.NewRequest("GET", "/", nil)
@@ -70,10 +68,8 @@ func TestCORSCustom(t *testing.T) {
 		c.Writer.Write([]byte("OK"))
 	})
 
-	// Add OPTIONS handler to match the router's behavior
-	r.Handle("OPTIONS /", func(c *router.Context) {
-		// This should never be called with custom CORS middleware without OptionsPassthrough
-	})
+	// Auto-register OPTIONS handlers for all registered routes
+	r.AutoRegisterOptions()
 
 	// Test with allowed origin
 	req := httptest.NewRequest("GET", "/", nil)
@@ -217,14 +213,20 @@ func TestCORSOptionsPassthrough(t *testing.T) {
 	}))
 
 	var optionsHandlerCalled bool
-	r.Handle("OPTIONS /", func(c *router.Context) {
+	// Use a non-root path to avoid normalization issues
+	r.GET("/test", func(c *router.Context) {
+		c.Writer.WriteHeader(200)
+		c.Writer.Write([]byte("GET handler"))
+	})
+	
+	r.Handle("OPTIONS /test", func(c *router.Context) {
 		optionsHandlerCalled = true
 		c.Writer.WriteHeader(200)
 		c.Writer.Write([]byte("OPTIONS handler called"))
 	})
 
 	// Test OPTIONS request with OptionsPassthrough enabled
-	req := httptest.NewRequest("OPTIONS", "/", nil)
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
 	req.Header.Set("Origin", "https://example.com")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -309,10 +311,8 @@ func TestPreflightRequests(t *testing.T) {
 		c.Writer.Write([]byte("OK"))
 	})
 
-	// Add OPTIONS handler to match the router's behavior
-	r.Handle("OPTIONS /", func(c *router.Context) {
-		// This should never be called with CORS middleware without OptionsPassthrough
-	})
+	// Auto-register OPTIONS handlers for all registered routes
+	r.AutoRegisterOptions()
 
 	// Test proper preflight request
 	req := httptest.NewRequest("OPTIONS", "/", nil)

--- a/router/router.go
+++ b/router/router.go
@@ -179,13 +179,16 @@ func (r *Router) Handle(pattern string, handler HandlerFunc, opts ...RouteOption
 	r.mux.Handle(method+" "+fullpath, httpHandler)
 
 	// Always register both versions of the path (with and without trailing slash)
-	var alternatePath string
-	if len(fullpath) > 1 && fullpath[len(fullpath)-1] == '/' {
-		alternatePath = fullpath[:len(fullpath)-1]
-	} else {
-		alternatePath = fullpath + "/"
+	// Skip for root path "/" to avoid creating "//"
+	if fullpath != "/" {
+		var alternatePath string
+		if len(fullpath) > 1 && fullpath[len(fullpath)-1] == '/' {
+			alternatePath = fullpath[:len(fullpath)-1]
+		} else {
+			alternatePath = fullpath + "/"
+		}
+		r.mux.Handle(method+" "+alternatePath, httpHandler)
 	}
-	r.mux.Handle(method+" "+alternatePath, httpHandler)
 }
 
 // GET registers a new GET route with the specified path and handler.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/joakimcarlsson/go-router/docs"
@@ -614,4 +615,511 @@ func BenchmarkRealWorldScenario(b *testing.B) {
 
 func createReaderFromBytes(b []byte) io.Reader {
 	return bytes.NewReader(b)
+}
+
+// Test middleware functionality
+func TestRouter_Use(t *testing.T) {
+	t.Run("single middleware", func(t *testing.T) {
+		r := router.New()
+		
+		// Middleware that adds a header
+		headerMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Middleware", "applied")
+				next.ServeHTTP(w, req)
+			})
+		}
+		
+		r.Use(headerMiddleware)
+		r.GET("/test", func(c *router.Context) {
+			c.JSON(200, map[string]string{"status": "ok"})
+		})
+		
+		req := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		
+		r.ServeHTTP(w, req)
+		
+		if w.Header().Get("X-Middleware") != "applied" {
+			t.Errorf("Expected middleware header to be set")
+		}
+		
+		if w.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
+	})
+	
+	t.Run("multiple middleware", func(t *testing.T) {
+		r := router.New()
+		
+		// Multiple middleware that modify request/response
+		middleware1 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Middleware-1", "first")
+				next.ServeHTTP(w, req)
+			})
+		}
+		
+		middleware2 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Middleware-2", "second")
+				next.ServeHTTP(w, req)
+			})
+		}
+		
+		middleware3 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Middleware-3", "third")
+				next.ServeHTTP(w, req)
+			})
+		}
+		
+		r.Use(middleware1, middleware2, middleware3)
+		r.GET("/test", func(c *router.Context) {
+			c.JSON(200, map[string]string{"status": "ok"})
+		})
+		
+		req := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		
+		r.ServeHTTP(w, req)
+		
+		// All middleware should have been applied
+		if w.Header().Get("X-Middleware-1") != "first" {
+			t.Errorf("Expected first middleware header to be set")
+		}
+		if w.Header().Get("X-Middleware-2") != "second" {
+			t.Errorf("Expected second middleware header to be set")
+		}
+		if w.Header().Get("X-Middleware-3") != "third" {
+			t.Errorf("Expected third middleware header to be set")
+		}
+	})
+	
+	t.Run("middleware execution order", func(t *testing.T) {
+		r := router.New()
+		
+		var executionOrder []string
+		
+		// Middleware that tracks execution order
+		middleware1 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				executionOrder = append(executionOrder, "before-1")
+				next.ServeHTTP(w, req)
+				executionOrder = append(executionOrder, "after-1")
+			})
+		}
+		
+		middleware2 := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				executionOrder = append(executionOrder, "before-2")
+				next.ServeHTTP(w, req)
+				executionOrder = append(executionOrder, "after-2")
+			})
+		}
+		
+		r.Use(middleware1, middleware2)
+		r.GET("/test", func(c *router.Context) {
+			executionOrder = append(executionOrder, "handler")
+			c.JSON(200, map[string]string{"status": "ok"})
+		})
+		
+		req := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		
+		r.ServeHTTP(w, req)
+		
+		expectedOrder := []string{"before-1", "before-2", "handler", "after-2", "after-1"}
+		if len(executionOrder) != len(expectedOrder) {
+			t.Fatalf("Expected %d execution steps, got %d", len(expectedOrder), len(executionOrder))
+		}
+		
+		for i, expected := range expectedOrder {
+			if executionOrder[i] != expected {
+				t.Errorf("Expected execution order[%d] to be '%s', got '%s'", i, expected, executionOrder[i])
+			}
+		}
+	})
+	
+	t.Run("middleware can modify request", func(t *testing.T) {
+		r := router.New()
+		
+		// Middleware that adds authentication info to context
+		authMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				ctx := context.WithValue(req.Context(), "user_id", "123")
+				ctx = context.WithValue(ctx, "username", "testuser")
+				next.ServeHTTP(w, req.WithContext(ctx))
+			})
+		}
+		
+		r.Use(authMiddleware)
+		r.GET("/profile", func(c *router.Context) {
+			userID := c.Request.Context().Value("user_id")
+			username := c.Request.Context().Value("username")
+			
+			c.JSON(200, map[string]interface{}{
+				"user_id":  userID,
+				"username": username,
+			})
+		})
+		
+		req := httptest.NewRequest("GET", "/profile", nil)
+		w := httptest.NewRecorder()
+		
+		r.ServeHTTP(w, req)
+		
+		if w.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
+		
+		var response map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Errorf("Failed to parse JSON response: %v", err)
+		}
+		
+		if response["user_id"] != "123" {
+			t.Errorf("Expected user_id to be '123', got %v", response["user_id"])
+		}
+		
+		if response["username"] != "testuser" {
+			t.Errorf("Expected username to be 'testuser', got %v", response["username"])
+		}
+	})
+	
+	t.Run("middleware can short-circuit request", func(t *testing.T) {
+		r := router.New()
+		
+		// Middleware that blocks unauthorized requests
+		authMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				authHeader := req.Header.Get("Authorization")
+				if authHeader != "Bearer valid-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					w.Write([]byte("Unauthorized"))
+					return // Short-circuit, don't call next handler
+				}
+				next.ServeHTTP(w, req)
+			})
+		}
+		
+		r.Use(authMiddleware)
+		r.GET("/protected", func(c *router.Context) {
+			c.JSON(200, map[string]string{"message": "Access granted"})
+		})
+		
+		// Test without valid token
+		req1 := httptest.NewRequest("GET", "/protected", nil)
+		w1 := httptest.NewRecorder()
+		
+		r.ServeHTTP(w1, req1)
+		
+		if w1.Code != 401 {
+			t.Errorf("Expected status 401, got %d", w1.Code)
+		}
+		
+		if w1.Body.String() != "Unauthorized" {
+			t.Errorf("Expected 'Unauthorized' response, got '%s'", w1.Body.String())
+		}
+		
+		// Test with valid token
+		req2 := httptest.NewRequest("GET", "/protected", nil)
+		req2.Header.Set("Authorization", "Bearer valid-token")
+		w2 := httptest.NewRecorder()
+		
+		r.ServeHTTP(w2, req2)
+		
+		if w2.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w2.Code)
+		}
+		
+		if !strings.Contains(w2.Body.String(), "Access granted") {
+			t.Errorf("Expected successful response, got '%s'", w2.Body.String())
+		}
+	})
+}
+
+// Test route group functionality
+func TestRouter_Group(t *testing.T) {
+	t.Run("simple group", func(t *testing.T) {
+		r := router.New()
+		
+		r.Group("/api", func(api *router.Router) {
+			api.GET("/users", func(c *router.Context) {
+				c.JSON(200, []string{"user1", "user2"})
+			})
+			
+			api.POST("/users", func(c *router.Context) {
+				c.JSON(201, map[string]string{"status": "created"})
+			})
+		})
+		
+		// Test GET /api/users
+		req1 := httptest.NewRequest("GET", "/api/users", nil)
+		w1 := httptest.NewRecorder()
+		r.ServeHTTP(w1, req1)
+		
+		if w1.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w1.Code)
+		}
+		
+		// Test POST /api/users
+		req2 := httptest.NewRequest("POST", "/api/users", nil)
+		w2 := httptest.NewRecorder()
+		r.ServeHTTP(w2, req2)
+		
+		if w2.Code != 201 {
+			t.Errorf("Expected status 201, got %d", w2.Code)
+		}
+	})
+	
+	t.Run("nested groups", func(t *testing.T) {
+		r := router.New()
+		
+		r.Group("/api", func(api *router.Router) {
+			api.GET("/health", func(c *router.Context) {
+				c.JSON(200, map[string]string{"status": "ok"})
+			})
+			
+			api.Group("/v1", func(v1 *router.Router) {
+				v1.GET("/users", func(c *router.Context) {
+					c.JSON(200, []string{"user1", "user2"})
+				})
+				
+				v1.Group("/admin", func(admin *router.Router) {
+					admin.GET("/settings", func(c *router.Context) {
+						c.JSON(200, map[string]string{"role": "admin"})
+					})
+				})
+			})
+			
+			api.Group("/v2", func(v2 *router.Router) {
+				v2.GET("/users", func(c *router.Context) {
+					c.JSON(200, []string{"user1", "user2", "user3"})
+				})
+			})
+		})
+		
+		// Test /api/health
+		req1 := httptest.NewRequest("GET", "/api/health", nil)
+		w1 := httptest.NewRecorder()
+		r.ServeHTTP(w1, req1)
+		
+		if w1.Code != 200 {
+			t.Errorf("Expected status 200 for /api/health, got %d", w1.Code)
+		}
+		
+		// Test /api/v1/users
+		req2 := httptest.NewRequest("GET", "/api/v1/users", nil)
+		w2 := httptest.NewRecorder()
+		r.ServeHTTP(w2, req2)
+		
+		if w2.Code != 200 {
+			t.Errorf("Expected status 200 for /api/v1/users, got %d", w2.Code)
+		}
+		
+		// Test /api/v1/admin/settings
+		req3 := httptest.NewRequest("GET", "/api/v1/admin/settings", nil)
+		w3 := httptest.NewRecorder()
+		r.ServeHTTP(w3, req3)
+		
+		if w3.Code != 200 {
+			t.Errorf("Expected status 200 for /api/v1/admin/settings, got %d", w3.Code)
+		}
+		
+		// Test /api/v2/users (different from v1)
+		req4 := httptest.NewRequest("GET", "/api/v2/users", nil)
+		w4 := httptest.NewRecorder()
+		r.ServeHTTP(w4, req4)
+		
+		if w4.Code != 200 {
+			t.Errorf("Expected status 200 for /api/v2/users, got %d", w4.Code)
+		}
+		
+		// Verify that v2 returns different data than v1
+		var v2Response []string
+		if err := json.Unmarshal(w4.Body.Bytes(), &v2Response); err != nil {
+			t.Errorf("Failed to parse v2 response: %v", err)
+		} else if len(v2Response) != 3 {
+			t.Errorf("Expected v2 to return 3 users, got %d", len(v2Response))
+		}
+	})
+	
+	t.Run("groups inherit parent middleware", func(t *testing.T) {
+		r := router.New()
+		
+		// Add global middleware
+		r.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("X-Global", "global")
+				next.ServeHTTP(w, req)
+			})
+		})
+		
+		r.Group("/api", func(api *router.Router) {
+			// Add API-specific middleware
+			api.Use(func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					w.Header().Set("X-API", "api")
+					next.ServeHTTP(w, req)
+				})
+			})
+			
+			api.GET("/test", func(c *router.Context) {
+				c.JSON(200, map[string]string{"status": "ok"})
+			})
+			
+			api.Group("/v1", func(v1 *router.Router) {
+				// Add v1-specific middleware
+				v1.Use(func(next http.Handler) http.Handler {
+					return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+						w.Header().Set("X-V1", "v1")
+						next.ServeHTTP(w, req)
+					})
+				})
+				
+				v1.GET("/nested", func(c *router.Context) {
+					c.JSON(200, map[string]string{"version": "v1"})
+				})
+			})
+		})
+		
+		// Test /api/test (should have global + api middleware)
+		req1 := httptest.NewRequest("GET", "/api/test", nil)
+		w1 := httptest.NewRecorder()
+		r.ServeHTTP(w1, req1)
+		
+		if w1.Header().Get("X-Global") != "global" {
+			t.Errorf("Expected global middleware header")
+		}
+		
+		if w1.Header().Get("X-API") != "api" {
+			t.Errorf("Expected API middleware header")
+		}
+		
+		// Test /api/v1/nested (should have global + api + v1 middleware)
+		req2 := httptest.NewRequest("GET", "/api/v1/nested", nil)
+		w2 := httptest.NewRecorder()
+		r.ServeHTTP(w2, req2)
+		
+		if w2.Header().Get("X-Global") != "global" {
+			t.Errorf("Expected global middleware header in nested route")
+		}
+		
+		if w2.Header().Get("X-API") != "api" {
+			t.Errorf("Expected API middleware header in nested route")
+		}
+		
+		if w2.Header().Get("X-V1") != "v1" {
+			t.Errorf("Expected V1 middleware header in nested route")
+		}
+	})
+	
+	t.Run("group with path parameters", func(t *testing.T) {
+		r := router.New()
+		
+		r.Group("/api/v1", func(v1 *router.Router) {
+			v1.GET("/users/{id}", func(c *router.Context) {
+				userID := c.Param("id")
+				c.JSON(200, map[string]string{
+					"user_id": userID,
+					"version": "v1",
+				})
+			})
+			
+			v1.GET("/users/{id}/posts/{postId}", func(c *router.Context) {
+				userID := c.Param("id")
+				postID := c.Param("postId")
+				c.JSON(200, map[string]string{
+					"user_id": userID,
+					"post_id": postID,
+				})
+			})
+		})
+		
+		// Test single parameter
+		req1 := httptest.NewRequest("GET", "/api/v1/users/123", nil)
+		w1 := httptest.NewRecorder()
+		r.ServeHTTP(w1, req1)
+		
+		if w1.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w1.Code)
+		}
+		
+		var response1 map[string]string
+		if err := json.Unmarshal(w1.Body.Bytes(), &response1); err != nil {
+			t.Errorf("Failed to parse response: %v", err)
+		}
+		
+		if response1["user_id"] != "123" {
+			t.Errorf("Expected user_id to be '123', got '%s'", response1["user_id"])
+		}
+		
+		// Test multiple parameters
+		req2 := httptest.NewRequest("GET", "/api/v1/users/456/posts/789", nil)
+		w2 := httptest.NewRecorder()
+		r.ServeHTTP(w2, req2)
+		
+		if w2.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w2.Code)
+		}
+		
+		var response2 map[string]string
+		if err := json.Unmarshal(w2.Body.Bytes(), &response2); err != nil {
+			t.Errorf("Failed to parse response: %v", err)
+		}
+		
+		if response2["user_id"] != "456" {
+			t.Errorf("Expected user_id to be '456', got '%s'", response2["user_id"])
+		}
+		
+		if response2["post_id"] != "789" {
+			t.Errorf("Expected post_id to be '789', got '%s'", response2["post_id"])
+		}
+	})
+	
+	t.Run("empty group prefix", func(t *testing.T) {
+		r := router.New()
+		
+		r.Group("", func(group *router.Router) {
+			group.GET("/test", func(c *router.Context) {
+				c.JSON(200, map[string]string{"group": "empty"})
+			})
+		})
+		
+		req := httptest.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		
+		if w.Code != 200 {
+			t.Errorf("Expected status 200, got %d", w.Code)
+		}
+	})
+	
+	t.Run("group with trailing slash", func(t *testing.T) {
+		r := router.New()
+		
+		r.Group("/api/", func(api *router.Router) {
+			api.GET("/users", func(c *router.Context) {
+				c.JSON(200, map[string]string{"path": "with_trailing_slash"})
+			})
+		})
+		
+		// Both /api/users and /api/users/ should work due to path normalization
+		req1 := httptest.NewRequest("GET", "/api/users", nil)
+		w1 := httptest.NewRecorder()
+		r.ServeHTTP(w1, req1)
+		
+		if w1.Code != 200 {
+			t.Errorf("Expected status 200 for /api/users, got %d", w1.Code)
+		}
+		
+		req2 := httptest.NewRequest("GET", "/api/users/", nil)
+		w2 := httptest.NewRecorder()
+		r.ServeHTTP(w2, req2)
+		
+		if w2.Code != 200 {
+			t.Errorf("Expected status 200 for /api/users/, got %d", w2.Code)
+		}
+	})
 }


### PR DESCRIPTION
This pull request introduces a comprehensive suite of integration and edge case tests for the `Setup` function and its options, as well as several improvements and refactorings to the router's handling of OPTIONS routes and path normalization. The main focus is on increasing test coverage for API documentation setup and improving the robustness and correctness of CORS and route handling in the router.

**Testing enhancements for API documentation setup:**

* Added a new `integration/setup_test.go` file containing extensive tests for `Setup` and `SetupOptions`, covering default values, custom options, path conflicts, security schemes, UI title handling, integration with real routes, complex configurations, and various edge cases.

**CORS middleware and OPTIONS route handling improvements:**

* Refactored CORS middleware tests in `router/middleware/cors/cors_test.go` to use `AutoRegisterOptions()` for automatically registering OPTIONS handlers, reducing manual boilerplate and improving test accuracy. [[1]](diffhunk://#diff-ce60d5d4272d7c1753d2fdf03b7b0d89ddc0d73f375e93ec58c57393e7ebc16eL19-R20) [[2]](diffhunk://#diff-ce60d5d4272d7c1753d2fdf03b7b0d89ddc0d73f375e93ec58c57393e7ebc16eL73-R72) [[3]](diffhunk://#diff-ce60d5d4272d7c1753d2fdf03b7b0d89ddc0d73f375e93ec58c57393e7ebc16eL312-R315)
* Updated the `TestCORSOptionsPassthrough` test to use a non-root path for OPTIONS requests, avoiding normalization issues and ensuring correct handler invocation.

**Router path normalization and route registration:**

* Improved the `Handle` method in `router/router.go` to skip alternate path registration for the root path `/`, preventing accidental creation of routes like `//`. [[1]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R182-R183) [[2]](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R192)