### PR TITLE
Task/ci cd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      
+      - name: Trigger Go module reindex (pkg.go.dev)
+        run: |
+          echo "Triggering Go module reindex at proxy.golang.org"
+          curl -sSf "https://proxy.golang.org/github.com/${GITHUB_REPOSITORY,,}/@v/${GITHUB_REF_NAME}.info"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            go-build: ~/.cache/go-build
+          - os: macos-latest
+            go-build: ~/Library/Caches/go-build
+          - os: windows-latest
+            go-build: ~\AppData\Local\go-build
+    name: ${{ matrix.os }} @ Go 1.22
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: on
+      GOPROXY: https://proxy.golang.org
+    steps:
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: false
+
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ matrix.go-build }}
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run Tests
+        run: go test -v ./...


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate testing and releasing for the project. The first workflow runs tests on multiple operating systems for pushes and pull requests, while the second workflow triggers a Go module reindex on release tags.

**Continuous Integration and Testing:**

* Added `.github/workflows/test.yml` to automatically run Go tests on Ubuntu, macOS, and Windows for pushes and pull requests to the `main` and `dev` branches. This workflow sets up Go 1.22, checks out the code, manages build caching, and runs tests across platforms.

**Release Automation:**

* Added `.github/workflows/release.yml` to trigger on any tag push, which checks out the repository and triggers a Go module reindex at `proxy.golang.org` to ensure new releases are available on `pkg.go.dev`.