### PR TITLE
Task/bug fixes

### DIFF
--- a/docs/options.go
+++ b/docs/options.go
@@ -648,3 +648,12 @@ func WithAPIKey() RouteOption {
 func WithOAuth2Scopes(scopes ...string) RouteOption {
 	return WithSecurity(map[string][]string{"oauth2": scopes})
 }
+
+// ExcludeFromDocs marks a route to be excluded from OpenAPI documentation.
+// This is useful for internal routes like health checks, documentation endpoints,
+// or any routes that should not appear in the public API documentation.
+func ExcludeFromDocs() RouteOption {
+	return func(m *metadata.RouteMetadata) {
+		m.ExcludeFromDocs = true
+	}
+}

--- a/integration/openapi.go
+++ b/integration/openapi.go
@@ -35,14 +35,13 @@ func NewRouterOpenAPIAdapter(r *router.Router, generator *openapi.Generator) *Ro
 
 // ExtractRouteInfo extracts OpenAPI route information from the router.
 // It converts the router's route metadata to the format expected by
-// the OpenAPI generator.
+// the OpenAPI generator, filtering out routes marked as ExcludeFromDocs.
 func (a *RouterOpenAPIAdapter) ExtractRouteInfo() []openapi.RouteInfo {
 	routes := a.Router.Routes()
 	routeInfos := make([]openapi.RouteInfo, 0, len(routes))
 
 	for _, route := range routes {
-		// Convert RouteMetadata to RouteInfo
-		if route.Metadata != nil {
+		if route.Metadata != nil && !route.Metadata.ExcludeFromDocs {
 			routeInfos = append(routeInfos, openapi.RouteInfoFromMetadata(*route.Metadata))
 		}
 	}

--- a/integration/swagger.go
+++ b/integration/swagger.go
@@ -48,17 +48,22 @@ func (s *SwaggerUIIntegration) WithUIConfig(config swagger.UIConfig) *SwaggerUII
 //  1. A route to serve the OpenAPI JSON specification
 //  2. A route to serve the Swagger UI that consumes the specification
 //
+// Both routes are automatically excluded from the OpenAPI documentation
+// to prevent them from appearing in the Swagger UI.
+//
 // Parameters:
 //   - r: The router to register routes on
 //   - specPath: The path to serve the OpenAPI JSON specification (e.g., "/openapi.json")
 //   - uiPath: The path to serve the Swagger UI (e.g., "/docs")
 func (s *SwaggerUIIntegration) SetupRoutes(r *router.Router, specPath, uiPath string) {
-	// Serve OpenAPI JSON
-	r.GET(specPath, router.FromHTTPHandler(http.HandlerFunc(s.OpenAPIAdapter.ServeHTTP)))
+	// Serve OpenAPI JSON - excluded from docs
+	r.GET(specPath, router.FromHTTPHandler(http.HandlerFunc(s.OpenAPIAdapter.ServeHTTP)),
+		router.ExcludeFromDocs())
 
 	// Configure UI to use the correct spec path
 	s.UIConfig.SpecURL = specPath
 
-	// Serve Swagger UI
-	r.GET(uiPath, router.FromHTTPHandler(swagger.Handler(s.UIConfig)))
+	// Serve Swagger UI - excluded from docs
+	r.GET(uiPath, router.FromHTTPHandler(swagger.Handler(s.UIConfig)),
+		router.ExcludeFromDocs())
 }

--- a/metadata/types.go
+++ b/metadata/types.go
@@ -36,6 +36,9 @@ type RouteMetadata struct {
 	RequestBody *RequestBody          `json:"requestBody,omitempty"`
 	Responses   map[string]Response   `json:"responses"`
 	Security    []SecurityRequirement `json:"security,omitempty"`
+
+	// Internal flag to exclude this route from OpenAPI documentation
+	ExcludeFromDocs bool `json:"-"`
 }
 
 // Parameter represents an API parameter such as path, query, header, or cookie parameters.

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -416,7 +416,5 @@ func (g *Generator) Generate(routes []RouteInfo) *metadata.Spec {
 		spec.Paths[route.Path()] = pathItem
 	}
 
-	delete(spec.Paths, "/openapi.json")
-
 	return spec
 }

--- a/router/route.go
+++ b/router/route.go
@@ -19,6 +19,9 @@ type Route struct {
 // It allows for fluent API-style configuration of routes with documentation.
 type RouteOption = docs.RouteOption
 
+// ExcludeFromDocs marks a route to be excluded from OpenAPI documentation.
+var ExcludeFromDocs = docs.ExcludeFromDocs
+
 // RouteConfig is used to provide configuration options for routes.
 // It contains both core routing properties and optional documentation metadata.
 type RouteConfig struct {

--- a/router/router.go
+++ b/router/router.go
@@ -168,6 +168,13 @@ func (r *Router) Handle(pattern string, handler HandlerFunc, opts ...RouteOption
 
 	fullpath := normalizePath(path.Join(r.prefix, subpath))
 
+	// Normalize paths by removing trailing slashes (except for root "/")
+	// This prevents pattern conflicts in Go's ServeMux where patterns like
+	// "GET /posts/{id}/replies" and "GET /posts/feed/" would conflict
+	if len(fullpath) > 1 && fullpath[len(fullpath)-1] == '/' {
+		fullpath = fullpath[:len(fullpath)-1]
+	}
+
 	// Create metadata for documentation
 	metadata := &metadata.RouteMetadata{
 		Method:     method,
@@ -212,18 +219,6 @@ func (r *Router) Handle(pattern string, handler HandlerFunc, opts ...RouteOption
 	}
 
 	r.mux.Handle(method+" "+fullpath, httpHandler)
-
-	// Always register both versions of the path (with and without trailing slash)
-	// Skip for root path "/" to avoid creating "//"
-	if fullpath != "/" {
-		var alternatePath string
-		if len(fullpath) > 1 && fullpath[len(fullpath)-1] == '/' {
-			alternatePath = fullpath[:len(fullpath)-1]
-		} else {
-			alternatePath = fullpath + "/"
-		}
-		r.mux.Handle(method+" "+alternatePath, httpHandler)
-	}
 }
 
 // GET registers a GET route with the given path and handler.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1118,7 +1118,7 @@ func TestRouter_Group(t *testing.T) {
 			})
 		})
 
-		// Both /api/users and /api/users/ should work due to path normalization
+		// Path normalization removes trailing slashes from group prefix and route path
 		req1 := httptest.NewRequest("GET", "/api/users", nil)
 		w1 := httptest.NewRecorder()
 		r.ServeHTTP(w1, req1)
@@ -1126,13 +1126,57 @@ func TestRouter_Group(t *testing.T) {
 		if w1.Code != 200 {
 			t.Errorf("Expected status 200 for /api/users, got %d", w1.Code)
 		}
+	})
 
-		req2 := httptest.NewRequest("GET", "/api/users/", nil)
+	t.Run("wildcard routes with trailing slash do not conflict", func(t *testing.T) {
+		r := router.New()
+
+		r.GET("/api/v1/posts/{id}/replies", func(c *router.Context) {
+			c.JSON(200, map[string]string{"endpoint": "replies", "id": c.Param("id")})
+		})
+
+		// Path normalization removes trailing slash to prevent conflicts
+		r.GET("/api/v1/posts/feed/", func(c *router.Context) {
+			c.JSON(200, map[string]string{"endpoint": "feed"})
+		})
+
+		req1 := httptest.NewRequest("GET", "/api/v1/posts/123/replies", nil)
+		w1 := httptest.NewRecorder()
+		r.ServeHTTP(w1, req1)
+
+		if w1.Code != 200 {
+			t.Errorf("Expected status 200 for posts/{id}/replies, got %d", w1.Code)
+		}
+
+		var response1 map[string]string
+		if err := json.Unmarshal(w1.Body.Bytes(), &response1); err != nil {
+			t.Errorf("Failed to parse response: %v", err)
+		}
+
+		if response1["endpoint"] != "replies" {
+			t.Errorf("Expected endpoint 'replies', got '%s'", response1["endpoint"])
+		}
+
+		if response1["id"] != "123" {
+			t.Errorf("Expected id '123', got '%s'", response1["id"])
+		}
+
+		// Access without trailing slash due to path normalization
+		req2 := httptest.NewRequest("GET", "/api/v1/posts/feed", nil)
 		w2 := httptest.NewRecorder()
 		r.ServeHTTP(w2, req2)
 
 		if w2.Code != 200 {
-			t.Errorf("Expected status 200 for /api/users/, got %d", w2.Code)
+			t.Errorf("Expected status 200 for posts/feed, got %d", w2.Code)
+		}
+
+		var response2 map[string]string
+		if err := json.Unmarshal(w2.Body.Bytes(), &response2); err != nil {
+			t.Errorf("Failed to parse response: %v", err)
+		}
+
+		if response2["endpoint"] != "feed" {
+			t.Errorf("Expected endpoint 'feed', got '%s'", response2["endpoint"])
 		}
 	})
 }


### PR DESCRIPTION
This pull request introduces two main improvements: (1) the ability to exclude specific routes from OpenAPI documentation (useful for internal endpoints like health checks or documentation UIs), and (2) enhanced path normalization in the router to prevent route conflicts, especially with trailing slashes. It also updates tests to cover these changes.

**OpenAPI Documentation Exclusion:**

* Added a new `ExcludeFromDocs` flag to `RouteMetadata` and a corresponding `ExcludeFromDocs` route option, allowing routes to be marked as excluded from generated OpenAPI docs. (`metadata/types.go` [[1]](diffhunk://#diff-bef7a44a54dcb191064cf994e7bf8c08a91c1264a2be18ba3b5e00f988576d89R39-R41) `docs/options.go` [[2]](diffhunk://#diff-cd53a2f26759ad8232d924bb966710e30668c41db2aa1cca7874806441f35897R651-R659) `router/route.go` [[3]](diffhunk://#diff-8eb9dc6b83178b6220b69c753cc258924e2407daefc512e5bf75c409289be477R22-R24)
* Updated the OpenAPI adapter and Swagger UI integration to respect this flag, ensuring internal routes (like `/openapi.json` and `/docs`) do not appear in the public API documentation. (`integration/openapi.go` [[1]](diffhunk://#diff-15329c80d984c05e8b911314c12ca308bedbeac039b9f7390213de57c424f58cL38-R44) `integration/swagger.go` [[2]](diffhunk://#diff-84a68a9055886936a036064b035a9b8de5ab9130e59b2f96b704f7999faef83fR51-R68) `openapi/generator.go` [[3]](diffhunk://#diff-591a766e1c534d4dfc216a17d947307f4b5f46d6e0c9be7a9667b203af762969L419-L420)

**Router Path Normalization:**

* Improved path normalization in the router to remove trailing slashes (except for root), preventing pattern conflicts in route registration and simplifying route handling. (`router/router.go` [router/router.goR171-R177](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964R171-R177))
* Removed the logic that registered both trailing and non-trailing slash versions of a route, as normalization now handles this. (`router/router.go` [router/router.goL215-L226](diffhunk://#diff-c399d26e7f23b713ce01946ac9e0e6f1fc94d692e8a086180191901da91b6964L215-L226))

**Testing Enhancements:**

* Added and updated tests to verify that path normalization prevents conflicts between similar routes with and without trailing slashes, and that endpoints behave as expected. (`router/router_test.go` [router/router_test.goL1121-R1179](diffhunk://#diff-04def44a4cd6a9c8549a994b1738c32da5163b39623f56abea1b20ae1ea14428L1121-R1179))