### PR TITLE
Add security middleware for HTTP headers

### DIFF
--- a/router/middleware/security/headers.go
+++ b/router/middleware/security/headers.go
@@ -1,0 +1,108 @@
+// Package security provides security-related HTTP middleware.
+package security
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Config defines security header options.
+type Config struct {
+	// HSTSMaxAge sets the Strict-Transport-Security max-age directive in seconds.
+	// Set to 0 to disable HSTS header. Default: 31536000 (1 year).
+	HSTSMaxAge int
+
+	// HSTSIncludeSubdomains includes subdomains in HSTS policy.
+	HSTSIncludeSubdomains bool
+
+	// HSTSPreload allows the domain to be included in browser preload lists.
+	HSTSPreload bool
+
+	// FrameOptions sets X-Frame-Options header.
+	// Common values: "DENY", "SAMEORIGIN". Empty string disables the header.
+	FrameOptions string
+
+	// ContentTypeNosniff enables X-Content-Type-Options: nosniff header.
+	ContentTypeNosniff bool
+
+	// XSSProtection enables X-XSS-Protection: 1; mode=block header.
+	// Note: This header is deprecated in modern browsers but may help older browsers.
+	XSSProtection bool
+
+	// ReferrerPolicy sets the Referrer-Policy header.
+	// Common values: "no-referrer", "strict-origin-when-cross-origin".
+	ReferrerPolicy string
+
+	// ContentSecurityPolicy sets the Content-Security-Policy header.
+	// This is application-specific and should be configured per-app.
+	ContentSecurityPolicy string
+
+	// PermissionsPolicy sets the Permissions-Policy header (formerly Feature-Policy).
+	PermissionsPolicy string
+}
+
+// DefaultConfig returns a secure default configuration.
+func DefaultConfig() Config {
+	return Config{
+		HSTSMaxAge:            31536000,
+		HSTSIncludeSubdomains: true,
+		HSTSPreload:           false,
+		FrameOptions:          "DENY",
+		ContentTypeNosniff:    true,
+		XSSProtection:         true,
+		ReferrerPolicy:        "strict-origin-when-cross-origin",
+	}
+}
+
+// Headers returns a middleware that sets security headers.
+func Headers(config Config) func(http.Handler) http.Handler {
+	hstsValue := ""
+	if config.HSTSMaxAge > 0 {
+		hstsValue = fmt.Sprintf("max-age=%d", config.HSTSMaxAge)
+		if config.HSTSIncludeSubdomains {
+			hstsValue += "; includeSubDomains"
+		}
+		if config.HSTSPreload {
+			hstsValue += "; preload"
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if hstsValue != "" {
+				w.Header().Set("Strict-Transport-Security", hstsValue)
+			}
+
+			if config.FrameOptions != "" {
+				w.Header().Set("X-Frame-Options", config.FrameOptions)
+			}
+
+			if config.ContentTypeNosniff {
+				w.Header().Set("X-Content-Type-Options", "nosniff")
+			}
+
+			if config.XSSProtection {
+				w.Header().Set("X-XSS-Protection", "1; mode=block")
+			}
+
+			if config.ReferrerPolicy != "" {
+				w.Header().Set("Referrer-Policy", config.ReferrerPolicy)
+			}
+
+			if config.ContentSecurityPolicy != "" {
+				w.Header().Set("Content-Security-Policy", config.ContentSecurityPolicy)
+			}
+
+			if config.PermissionsPolicy != "" {
+				w.Header().Set("Permissions-Policy", config.PermissionsPolicy)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// Default returns a middleware with default security headers.
+func Default() func(http.Handler) http.Handler {
+	return Headers(DefaultConfig())
+}

--- a/router/middleware/security/headers_test.go
+++ b/router/middleware/security/headers_test.go
@@ -1,0 +1,225 @@
+package security
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHeaders_Default(t *testing.T) {
+	handler := Default()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	tests := []struct {
+		header   string
+		expected string
+	}{
+		{"Strict-Transport-Security", "max-age=31536000; includeSubDomains"},
+		{"X-Frame-Options", "DENY"},
+		{"X-Content-Type-Options", "nosniff"},
+		{"X-XSS-Protection", "1; mode=block"},
+		{"Referrer-Policy", "strict-origin-when-cross-origin"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.header, func(t *testing.T) {
+			got := rec.Header().Get(tc.header)
+			if got != tc.expected {
+				t.Errorf("%s: expected %q, got %q", tc.header, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestHeaders_HSTS(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected string
+	}{
+		{
+			name: "basic HSTS",
+			config: Config{
+				HSTSMaxAge: 3600,
+			},
+			expected: "max-age=3600",
+		},
+		{
+			name: "HSTS with subdomains",
+			config: Config{
+				HSTSMaxAge:            3600,
+				HSTSIncludeSubdomains: true,
+			},
+			expected: "max-age=3600; includeSubDomains",
+		},
+		{
+			name: "HSTS with preload",
+			config: Config{
+				HSTSMaxAge:            31536000,
+				HSTSIncludeSubdomains: true,
+				HSTSPreload:           true,
+			},
+			expected: "max-age=31536000; includeSubDomains; preload",
+		},
+		{
+			name: "HSTS disabled",
+			config: Config{
+				HSTSMaxAge: 0,
+			},
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Headers(tc.config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			got := rec.Header().Get("Strict-Transport-Security")
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestHeaders_FrameOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"DENY", "DENY", "DENY"},
+		{"SAMEORIGIN", "SAMEORIGIN", "SAMEORIGIN"},
+		{"disabled", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Headers(Config{FrameOptions: tc.value})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			got := rec.Header().Get("X-Frame-Options")
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestHeaders_ContentTypeNosniff(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected string
+	}{
+		{"enabled", true, "nosniff"},
+		{"disabled", false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Headers(Config{ContentTypeNosniff: tc.enabled})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			got := rec.Header().Get("X-Content-Type-Options")
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestHeaders_CustomCSP(t *testing.T) {
+	csp := "default-src 'self'; script-src 'self' 'unsafe-inline'"
+
+	handler := Headers(Config{
+		ContentSecurityPolicy: csp,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	got := rec.Header().Get("Content-Security-Policy")
+	if got != csp {
+		t.Errorf("expected %q, got %q", csp, got)
+	}
+}
+
+func TestHeaders_PermissionsPolicy(t *testing.T) {
+	policy := "geolocation=(), microphone=()"
+
+	handler := Headers(Config{
+		PermissionsPolicy: policy,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	got := rec.Header().Get("Permissions-Policy")
+	if got != policy {
+		t.Errorf("expected %q, got %q", policy, got)
+	}
+}
+
+func TestHeaders_ReferrerPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"no-referrer", "no-referrer", "no-referrer"},
+		{"strict-origin-when-cross-origin", "strict-origin-when-cross-origin", "strict-origin-when-cross-origin"},
+		{"disabled", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := Headers(Config{ReferrerPolicy: tc.value})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			got := rec.Header().Get("Referrer-Policy")
+			if got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new HTTP middleware package for setting security-related headers and provides comprehensive unit tests to ensure correct behavior. The middleware is configurable, allowing for flexible and secure default settings, and covers common security headers such as HSTS, X-Frame-Options, Content Security Policy, and more.