### PR TITLE
Add support for array enum query parameters and enhance parameter options with style and explode attributes

### DIFF
--- a/openapi/metadata.go
+++ b/openapi/metadata.go
@@ -70,6 +70,8 @@ func applyOption(m *RouteMetadata, opt router.RouteOption) {
 			Required:    o.Required,
 			Description: o.Description,
 			Schema:      o.Schema,
+			Style:       o.Style,
+			Explode:     o.Explode,
 		})
 
 	case RequestBodyOption:

--- a/openapi/options.go
+++ b/openapi/options.go
@@ -41,6 +41,8 @@ type ParameterWithSchemaOption struct {
 	Required    bool
 	Description string
 	Schema      Schema
+	Style       string
+	Explode     *bool
 }
 
 // RequestBodyOption adds a request body with a specific content type.
@@ -265,6 +267,24 @@ func WithRegexQueryParam(name, pattern string, required bool, description string
 			Type:    "string",
 			Pattern: pattern,
 			Example: example,
+		},
+	}
+}
+
+func WithEnumArrayQueryParam(name string, required bool, description string, explode bool, values []interface{}) router.RouteOption {
+	return ParameterWithSchemaOption{
+		Name:        name,
+		In:          "query",
+		Required:    required,
+		Description: description,
+		Style:       "form",
+		Explode:     &explode,
+		Schema: Schema{
+			Type: "array",
+			Items: &Schema{
+				Type: "string",
+				Enum: values,
+			},
 		},
 	}
 }

--- a/openapi/types.go
+++ b/openapi/types.go
@@ -60,6 +60,8 @@ type Parameter struct {
 	Description string      `json:"description,omitempty"`
 	Schema      Schema      `json:"schema"`
 	Example     interface{} `json:"example,omitempty"`
+	Style       string      `json:"style,omitempty"`
+	Explode     *bool       `json:"explode,omitempty"`
 }
 
 func (p Parameter) MarshalJSON() ([]byte, error) {
@@ -70,6 +72,8 @@ func (p Parameter) MarshalJSON() ([]byte, error) {
 		Description string      `json:"description,omitempty"`
 		Schema      Schema      `json:"schema"`
 		Example     interface{} `json:"example,omitempty"`
+		Style       string      `json:"style,omitempty"`
+		Explode     *bool       `json:"explode,omitempty"`
 	}
 	return json.Marshal(ParameterJSON(p))
 }


### PR DESCRIPTION
This pull request extends support for OpenAPI query parameter options, specifically adding the ability to define parameters with array enums and control their serialization style and explode behavior. The changes enhance the flexibility and accuracy of OpenAPI metadata generation for query parameters.