### PR TITLE
Update router import paths to v2 across multiple files and update go.mod dependencies

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 // Generator handles OpenAPI 3.0 specification generation from router routes.

--- a/openapi/go.mod
+++ b/openapi/go.mod
@@ -2,6 +2,6 @@ module github.com/joakimcarlsson/go-router/openapi
 
 go 1.22
 
-require github.com/joakimcarlsson/go-router/router v0.0.0
+require github.com/joakimcarlsson/go-router/router/v2 v2.0.0
 
-replace github.com/joakimcarlsson/go-router/router => ../router
+replace github.com/joakimcarlsson/go-router/router/v2 => ../router

--- a/openapi/metadata.go
+++ b/openapi/metadata.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"reflect"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 // MetadataFromOptions converts a slice of router.RouteOption to RouteMetadata.

--- a/openapi/options.go
+++ b/openapi/options.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"reflect"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 // OperationIDOption sets the operationId for a route.

--- a/outputcache/cache.go
+++ b/outputcache/cache.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 // contextKey is used to store cache-related data in request context.

--- a/outputcache/cache_test.go
+++ b/outputcache/cache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 func TestCache_Basic(t *testing.T) {

--- a/outputcache/etag_test.go
+++ b/outputcache/etag_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 func TestCache_ETag(t *testing.T) {

--- a/outputcache/go.mod
+++ b/outputcache/go.mod
@@ -2,6 +2,6 @@ module github.com/joakimcarlsson/go-router/outputcache
 
 go 1.22
 
-require github.com/joakimcarlsson/go-router/router v0.0.0
+require github.com/joakimcarlsson/go-router/router/v2 v2.0.0
 
-replace github.com/joakimcarlsson/go-router/router => ../router
+replace github.com/joakimcarlsson/go-router/router/v2 => ../router

--- a/outputcache/profiles_test.go
+++ b/outputcache/profiles_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 func TestProfiles_AddGet(t *testing.T) {

--- a/outputcache/tags_test.go
+++ b/outputcache/tags_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 func TestCache_Tags(t *testing.T) {

--- a/router/go.mod
+++ b/router/go.mod
@@ -1,3 +1,3 @@
-module github.com/joakimcarlsson/go-router/router
+module github.com/joakimcarlsson/go-router/router/v2
 
 go 1.22

--- a/router/middleware/cors/cors_test.go
+++ b/router/middleware/cors/cors_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 func TestCORSDefault(t *testing.T) {

--- a/router/middleware/recovery/recovery_test.go
+++ b/router/middleware/recovery/recovery_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/joakimcarlsson/go-router/router"
-	"github.com/joakimcarlsson/go-router/router/middleware/recovery"
+	"github.com/joakimcarlsson/go-router/router/v2"
+	"github.com/joakimcarlsson/go-router/router/v2/middleware/recovery"
 )
 
 func TestRecovery_Default(t *testing.T) {

--- a/swaggerui/go.mod
+++ b/swaggerui/go.mod
@@ -3,11 +3,11 @@ module github.com/joakimcarlsson/go-router/swaggerui
 go 1.22
 
 require (
-	github.com/joakimcarlsson/go-router/openapi v0.0.0
-	github.com/joakimcarlsson/go-router/router v0.0.0
+	github.com/joakimcarlsson/go-router/openapi v1.0.0
+	github.com/joakimcarlsson/go-router/router/v2 v2.0.0
 )
 
 replace (
 	github.com/joakimcarlsson/go-router/openapi => ../openapi
-	github.com/joakimcarlsson/go-router/router => ../router
+	github.com/joakimcarlsson/go-router/router/v2 => ../router
 )

--- a/swaggerui/setup.go
+++ b/swaggerui/setup.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/joakimcarlsson/go-router/openapi"
-	"github.com/joakimcarlsson/go-router/router"
+	"github.com/joakimcarlsson/go-router/router/v2"
 )
 
 // Setup provides integration between the router, OpenAPI generator, and Swagger UI.


### PR DESCRIPTION
This pull request updates the `go-router` package to use the new v2 module path across all relevant packages and test files. It also updates all `go.mod` files to require and replace the new v2 module, ensuring consistent dependency management and compatibility with the latest version.